### PR TITLE
if we could not get the l3 device in olsrd_write_interface then try to g...

### DIFF
--- a/olsrd/files/olsrd.init
+++ b/olsrd/files/olsrd.init
@@ -564,6 +564,12 @@ olsrd_write_interface() {
 			if network_get_device IFNAME "$interface"; then
 				ifnames="$ifnames \"$IFNAME\""
 				ifsglobal="$ifsglobal $IFNAME"
+			elif network_get_physdev IFNAME "$interface"; then
+				local proto="$(uci -q get network.${interface}.proto)"
+				if [ "$proto" = "static" -o "$proto" = "none" ]; then
+					ifnames="$ifnames \"$IFNAME\""
+					ifsglobal="$ifsglobal $IFNAME"
+				fi
 			else
 				log "$funcname() Warning: Interface '$interface' not found, skipped"
 			fi


### PR DESCRIPTION
...et the

```
physical device instead. But only if the protocoll is "static" or "none".
This is useful to write Interfaces in the resulting olsrd.conf file which
are not up at the time olsrd is starting (e.g. tunnel interfaces):
```
