### PR TITLE
Fix a regression in the jsoninfo plugin which was introduced in olsrd 0.6.6

### DIFF
--- a/olsrd/patches/001-fix-jsoninfo.patch
+++ b/olsrd/patches/001-fix-jsoninfo.patch
@@ -1,16 +1,22 @@
+diff --git a/lib/jsoninfo/src/olsrd_jsoninfo.c b/lib/jsoninfo/src/olsrd_jsoninfo.c
+index 3f7b7b9..966292c 100644
 --- a/lib/jsoninfo/src/olsrd_jsoninfo.c
 +++ b/lib/jsoninfo/src/olsrd_jsoninfo.c
-@@ -1283,8 +1283,11 @@ send_info(unsigned int send_what, int the_socket)
+@@ -1283,7 +1283,7 @@ send_info(unsigned int send_what, int the_socket)
    abuf_init(&abuf, 32768);
  
   // only add if outputing JSON
 -  if (send_what & SIW_ALL) abuf_json_open_array_entry(&abuf);
--
-+  if (send_what & SIW_ALL) {
-+    abuf_json_open_array_entry(&abuf);
-+    entrynumber[0] = 0;
-+    currentjsondepth = 0;
-+  }
++  if (send_what & SIW_ALL) abuf_puts(&abuf, "{");
+ 
    if ((send_what & SIW_LINKS) == SIW_LINKS) ipc_print_links(&abuf);
    if ((send_what & SIW_NEIGHBORS) == SIW_NEIGHBORS) ipc_print_neighbors(&abuf);
-   if ((send_what & SIW_TOPOLOGY) == SIW_TOPOLOGY) ipc_print_topology(&abuf);
+@@ -1305,7 +1305,7 @@ send_info(unsigned int send_what, int the_socket)
+     abuf_json_int(&abuf, "timeSinceStartup", now_times);
+     if(*uuid != 0)
+       abuf_json_string(&abuf, "uuid", uuid);
+-    abuf_json_close_array_entry(&abuf);
++      abuf_puts(&abuf, "}\n");
+   }
+ 
+   /* this outputs the olsrd.conf text directly, not JSON */


### PR DESCRIPTION
After a fix which was intended to fix jsoninfo output the plugin broke in another place and produced invalid output. This patch fixes this. It will only be needed for 0.6.6 because the fix was already pushed to master. For a discussion of the bug and fix see http://olsr.org/bugs/view.php?id=40
