### PR TITLE
Add package for babel source-routing branch

### DIFF
--- a/babels/Makefile
+++ b/babels/Makefile
@@ -1,0 +1,63 @@
+#
+# Copyright (C) 2007-2009 OpenWrt.org
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=babels
+PKG_SOURCE_VERSION:=757af8018a6e51ba64994d4834d41d4da8377e09
+PKG_VERSION:=2013-12-14-$(PKG_SOURCE_VERSION)
+PKG_RELEASE:=1
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://git.wifi.pps.univ-paris-diderot.fr/babels
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/babels
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=Routing and Redirection
+  TITLE:=A loop-free distance-vector routing protocol (source-specific)
+  URL:=http://www.pps.univ-paris-diderot.fr/~jch/software/babel/
+  MAINTAINER:=Steven Barth <cyrus@openwrt.org>
+  DEPENDS:=+kmod-ipv6
+endef
+
+define Package/babels/description
+ Babel is a loop-avoiding distance-vector routing protocol roughly based
+ on DSDV and AODV, but with provisions for link cost estimation and
+ redistribution of routes from other routing protocols.
+ While it is optimised for wireless mesh networks, Babel will also work
+ efficiently on wired networks. It will generate between 1.2 and 2.4 times
+ the amount of routing traffic that RIPng would generate, while
+ never counting to infinity.
+ This is experimental source routing branch, and should be only used if you
+ know what you are doing.
+endef
+
+define Package/babels/conffiles
+/etc/babeld.conf
+/etc/config/babeld
+endef
+
+MAKE_FLAGS+= \
+	CFLAGS="$(TARGET_CFLAGS) -DIPV6_SUBTREES" \
+	LDLIBS="" \
+
+define Package/babels/install
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/babeld $(1)/usr/sbin/
+	$(INSTALL_DIR) $(1)/etc
+	$(INSTALL_CONF) ./files/babeld.conf $(1)/etc/
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_CONF) ./files/babeld.config $(1)/etc/config/babeld
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/babeld.init $(1)/etc/init.d/babeld
+endef
+
+$(eval $(call BuildPackage,babels))

--- a/babels/files/babeld.conf
+++ b/babels/files/babeld.conf
@@ -1,0 +1,38 @@
+# babel config file
+#
+# This config file simply documents sample entries. 
+# "redistribute" means: redistribute routes from other routing protocols
+# into babel. "local" means addresses assigned to local interfaces.
+#
+# You do not need to edit this file: you can use /etc/config/babeld
+# instead (sections "interface" and "filter").  Both files can be used
+# simultaneously (the rules of this file are executed first).
+
+# the default rules are:
+#
+## redistribute local 
+## redistribute deny
+#
+# this says, redistribute local addresses but no other routes
+
+
+# redistribute IPv4 default route into babel 
+## redistribute local ip 0.0.0.0/0 le 0 metric 128
+
+# same but for IPv6
+## redistribute local ip ::/0 le 0 metric 128
+
+
+# don't redistribute all local addresses, only selected ones
+# after the first line, the "deny" rules kicks in. After the "deny"
+# no redistribute local rules are going to match
+## redistribute local ip 192.160.4.0/24 
+## redistribute local deny
+
+
+# Babel refuses to redistribute routes with a protocol number of "boot";
+# this is standard practice, and means that you cannot easily
+# redistribute the default route installed by dhcp.  It is however
+# possible to redistribute such route by explicitly specifying "proto 3"
+# on the redistribute line.
+## redistribute ip 0.0.0.0/0 le 0 proto 3 metric 128

--- a/babels/files/babeld.config
+++ b/babels/files/babeld.config
@@ -1,0 +1,72 @@
+package babeld
+
+config general
+	# option 'multicast_address' 'ff02:0:0:0:0:0:1:6'
+	# option 'port' '6696'
+	# option 'state_file' '/var/lib/babel-state'
+	# option 'hello_interval' '4'
+	# option 'wired_hello_interval' '20'
+	# option 'diversity' '0,128'
+	# option 'smoothing_half_time' '4'
+	# option 'kernel_priority' '0'
+	# Do not use this option unless you know what you are doing, as it can
+	# cause persistent route flapping.
+	## option 'duplication_priority' '0'
+	# option 'carrier_sense' 'false'
+	# option 'assume_wireless' 'false'
+	# option 'no_split_horizon' 'false'
+	# option 'debug' '0'
+	# Listen for connections from a front-end, e.g. on port 33123.
+	## option 'local_server' '33123'
+	# option 'random_router_id' 'false'
+	# Keep unfeasible routes
+	## option 'keep_unfeasible' 'false'
+	# Use the given kernel routing table for routes inserted by babeld.
+	## option 'export_table' '0'
+	# Export routes from the given kernel routing tables.
+	## list 'import_table' '0'
+	## list 'import_table' '42'
+	# The configuration file is not necessary since you can do everything
+	# from this file.
+	# option 'conf_file' '/etc/babeld.conf'
+	# option 'log_file' '/var/log/babeld.log'
+
+# You can use aliases (like lan, wlan) or real names (like eth0.0).
+# If you use an alias, it must be already defined when babeld starts.
+# Otherwise, the name is taken literally and the interface can be
+# brought up later (useful for tunnels for instance).
+config interface wlan
+	# Remove this line to enable babeld on this interface
+	option 'ignore' 'true'
+	# option 'wired' 'auto'
+	# option 'link_quality' 'auto'
+	# option 'split_horizon' 'auto'
+	# The default is 96 for wired interfaces, and 256 for wireless ones
+	## option 'rxcost' '256'
+	# The default is specified with the -h and -H command-line flags.
+	## option 'hello_interval' '4'
+	# This can be set to a fairly large  value,  unless significant
+	# packet loss is expected.  The default is four times the hello
+	# interval.
+	## option 'update_interval' '16'
+
+config interface lan
+	option 'ignore' 'true'
+
+# A filter consists in a type ('in', 'out' or 'redistribute'), an action
+# ('allow', 'deny' or 'metric xxx') and a set of selectors ('ip', 'eq',
+# etc.).  See /etc/babeld.conf for more details.
+# Here is a sample filter wich redistributes the default route if its
+# protocol number is "boot", e.g. when it installed by dhcp.  It is
+# disabled by default.
+config filter
+	option 'ignore' 'true'
+	# Type
+	option 'type' 'redistribute'
+	# Selectors: ip, eq, le, ge, neigh, id, proto, local, if
+	option 'ip' '0.0.0.0/0' 
+	option 'le' '0'
+	option 'proto' '3'
+	# Action 
+	option 'action' 'metric 128'
+

--- a/babels/files/babeld.init
+++ b/babels/files/babeld.init
@@ -1,0 +1,154 @@
+#!/bin/sh /etc/rc.common
+
+START=70
+
+pidfile='/var/run/babeld.pid'
+EXTRA_COMMANDS="status"
+EXTRA_HELP="        status Dump Babel's table to the log file."
+
+listen_ifname() {
+	local ifname=$(uci_get_state network "$1" ifname "$1")
+	local switch="$2"
+	append args "$switch $ifname"
+	append interfaces "$ifname"
+}
+
+append_ifname() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local _name
+	config_get _name "$section" "$option"
+	[ -z "$_name" ] && return 0
+	local ifname=$(uci_get_state network "$_name" ifname "$_name")
+	append args "$switch $ifname"
+}
+
+append_bool() {
+	local section="$1"
+	local option="$2"
+	local value="$3"
+	local _loctmp
+	config_get_bool _loctmp "$section" "$option" 0
+	[ "$_loctmp" -gt 0 ] && append args "$value"
+}
+
+append_switch() {
+	local value="$1"
+	local switch="$2"
+	append args "$switch $value"
+}
+
+append_parm() {
+	local section="$1"
+	local option="$2"
+	local switch="$3"
+	local _loctmp
+	config_get _loctmp "$section" "$option"
+	[ -z "$_loctmp" ] && return 0
+	append args "$switch $_loctmp"
+}
+
+babel_filter() {
+	local cfg="$1"
+	local _loctmp
+
+	local _ignored
+	config_get_bool _ignored "$cfg" 'ignore' 0
+	[ "$_ignored" -eq 1 ] && return 0
+	
+	append args "-C '"
+
+	append_parm "$cfg" 'type' ''
+
+	append_bool "$cfg" 'local' 'local'
+
+	append_parm "$cfg" 'ip' 'ip'
+	append_parm "$cfg" 'eq' 'eq'
+	append_parm "$cfg" 'le' 'le'
+	append_parm "$cfg" 'ge' 'ge'
+	append_parm "$cfg" 'src_ip' 'src-ip'
+	append_parm "$cfg" 'src_eq' 'src-eq'
+	append_parm "$cfg" 'src_le' 'src-le'
+	append_parm "$cfg" 'src_ge' 'src-ge'
+	append_parm "$cfg" 'neigh' 'neigh'
+	append_parm "$cfg" 'id' 'id'
+	append_parm "$cfg" 'proto' 'proto'
+
+	append_ifname "$cfg" 'if' 'if'
+
+	append_parm "$cfg" 'action' ''
+
+	append args ' ' "'"
+}
+
+babel_addif() {
+	local cfg="$1"
+
+	local _ignored
+	config_get_bool _ignored "$cfg" 'ignore' 0
+	[ "$_ignored" -eq 1 ] && return 0
+	
+	listen_ifname "$cfg" "-C 'interface"
+
+	append_parm "$cfg" 'wired' 'wired'
+	append_parm "$cfg" 'link_quality' 'link-quality'
+	append_parm "$cfg" 'split_horizon' 'split-horizon'
+	append_parm "$cfg" 'rxcost' 'rxcost'
+	append_parm "$cfg" 'hello_interval' 'hello-interval'
+	append_parm "$cfg" 'update_interval' 'update-interval'
+
+	append args ' ' "'"
+}
+
+babel_config() {
+	local cfg="$1"
+
+	append_bool "$cfg" 'carrier_sense' '-l'
+	append_bool "$cfg" 'assume_wireless' '-w'
+	append_bool "$cfg" 'no_split_horizon' '-s'
+	append_bool "$cfg" 'keep_unfeasible' '-u'
+	append_bool "$cfg" 'random_router_id' '-r'
+
+	append_parm "$cfg" 'multicast_address' '-m'
+	append_parm "$cfg" 'port' '-p'
+	append_parm "$cfg" 'state_file' '-S'
+	append_parm "$cfg" 'hello_interval' '-h'
+	append_parm "$cfg" 'wired_hello_interval' '-H'
+	append_parm "$cfg" 'diversity' '-z'
+	append_parm "$cfg" 'smoothing_half_time' '-M'
+	append_parm "$cfg" 'kernel_priority' '-k'
+	append_parm "$cfg" 'duplication_priority' '-A'
+	append_parm "$cfg" 'debug' '-d'
+	append_parm "$cfg" 'local_server' '-g'
+	append_parm "$cfg" 'export_table' '-t'
+	config_list_foreach "$cfg" 'import_table' append_switch '-T'
+	append_parm "$cfg" 'conf_file' '-c'
+	append_parm "$cfg" 'log_file' '-L'
+}
+
+start() {
+	mkdir -p /var/lib
+	config_load babeld
+	unset args
+	unset interfaces
+	config_foreach babel_config general
+	config_foreach babel_addif interface
+	config_foreach babel_filter filter
+	[ -z "$interfaces" ] && return 0
+	eval "/usr/sbin/babeld -D -I $pidfile $args $interfaces"
+}
+
+stop() {
+	[ -f "$pidfile" ] && kill $(cat $pidfile)
+  # avoid race-condition on restart: wait for
+  # babeld to die for real.
+  [ -f "$pidfile" ] && sleep 1
+  [ -f "$pidfile" ] && sleep 1
+  [ -f "$pidfile" ] && sleep 1
+  [ -f "$pidfile" ] && exit 42
+}
+
+status() {
+	[ -f "$pidfile" ] && kill -USR1 $(cat $pidfile)
+}


### PR DESCRIPTION
This packages babel's source-routing branch which allows distributing source-restricted routes which is needed for proper IPv6 multihoming.
