### PR TITLE
ahcpd: fix build with ARM VFP toolchains

### DIFF
--- a/ahcpd/Makefile
+++ b/ahcpd/Makefile
@@ -38,6 +38,9 @@ define Package/ahcpd/conffiles
 /etc/config/ahcpd
 endef
 
+MAKE_FLAGS += \
+	      EXTRA_DEFINES="$(TARGET_CFLAGS)"
+
 define Package/ahcpd/install
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_DIR) $(1)/etc/ahcp


### PR DESCRIPTION
Building ahcpd for an ARM VFP enabled target will produce the following build
failure:

arm-openwrt-linux-uclibcgnueabi-gcc -Os -g -Wall
-L/exp00/fainelli/openwrt/trunk/staging_dir/target-arm_mpcore+vfp_uClibc-0.9.33.2_eabi/usr/lib
-L/exp00/fainelli/openwrt/trunk/staging_dir/target-arm_mpcore+vfp_uClibc-0.9.33.2_eabi/lib
-L/exp00/fainelli/openwrt/trunk/staging_dir/toolchain-arm_mpcore+vfp_gcc-4.6-linaro_uClibc-0.9.33.2_eabi/usr/lib
-L/exp00/fainelli/openwrt/trunk/staging_dir/toolchain-arm_mpcore+vfp_gcc-4.6-linaro_uClibc-0.9.33.2_eabi/lib
-o ahcpd ahcpd.o monotonic.o transport.o prefix.o configure.o config.o lease.o
-lrt
/exp00/fainelli/openwrt/trunk/staging_dir/toolchain-arm_mpcore+vfp_gcc-4.6-linaro_uClibc-0.9.33.2_eabi/lib/gcc/arm-openwrt-linux-uclibcgnueabi/4.6.4/../../../../arm-openwrt-linux-uclibcgnueabi/bin/ld:
error: ahcpd uses VFP register arguments, ahcpd.o does not

fix this by making sure that TARGET_CFLAGS are correctly passed down to ahcpd's
Makefile and used as the compiler CFLAGS by using EXTRA_DEFINES.

Signed-off-by: Florian Fainelli florian@openwrt.org
