### PR TITLE
Wait for mac80211.sh to finish before starting BMX6, otherwise routing rule for table 60 is not added

### DIFF
--- a/bmx6/files/etc/init.d/bmx6
+++ b/bmx6/files/etc/init.d/bmx6
@@ -27,6 +27,7 @@ PID=/var/run/bmx6/pid
 
 start() {
 	cd /root/
+	while pgrep -f mac80211.sh ; do sleep 1; done
 	ulimit -c 20000
 	$BIN -f $CONF -d0 > /dev/null &
 }


### PR DESCRIPTION
Added a line to wait for the mac80211.sh process to finish before BMX6 is started at boot. It seems that, with OpenWrt trunk, BMX6 will start before the whole network is configured and the routing rule for the protocol is not added.
