### PR TITLE
Fix broken olsrd init script activation

### DIFF
--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2008-2013 OpenWrt.org
 
-. /lib/functions/olsrd.sh
+. $IPKG_INSTROOT/lib/functions/olsrd.sh
 
 START=65
 

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2008-2013 OpenWrt.org
 
-. /lib/functions/olsrd.sh
+. $IPKG_INSTROOT/lib/functions/olsrd.sh
 
 START=65
 


### PR DESCRIPTION
Your recent merge broke the `olsrd` package init script activation because the new init.d script includes another script (`/lib/functions/olsrd.sh`) using an absolute path which is invalid in imagebuilder context as it must be prefixed by the build root directory. You should prefix the root by $IPKG_INSTROOT which is what this pull request adds.
