### PR TITLE
babeld: create the directory for the config file and restart babeld on ifup

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -54,6 +54,9 @@ define Package/babeld/install
 	$(INSTALL_CONF) ./files/babeld.config $(1)/etc/config/babeld
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/babeld.init $(1)/etc/init.d/babeld
+	$(INSTALL_DIR) $(1)/etc/hotplug.d
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/net
+	$(INSTALL_BIN) ./files/babeld.hotplug $(1)/etc/hotplug.d/net/30-babeld
 endef
 
 $(eval $(call BuildPackage,babeld))

--- a/babeld/files/babeld.hotplug
+++ b/babeld/files/babeld.hotplug
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+[ "$ACTION" = add ] || exit 0
+
+logger -t babeld "Reloading babeld due to $ACTION of interface $INTERFACE"
+
+/etc/init.d/babeld enabled && /etc/init.d/babeld reload

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -199,6 +199,7 @@ babel_config_cb() {
 
 start() {
 	mkdir -p /var/lib
+	mkdir -p /var/etc
 	# Start by emptying the generated config file
 	>"$CONFIGFILE"
 	# First load the whole config file, without callbacks, so that we are


### PR DESCRIPTION
babeld.init couldn't create the config file because of a nonexistent directory. This commit creates the directory before writing to the config file.
