### PR TITLE
batman-adv: Preserve configuration file on update

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -43,6 +43,10 @@ define KernelPackage/batman-adv/config
 	source "$(SOURCE)/Config.in"
 endef
 
+define Package/kmod-batman-adv/conffiles
+/etc/config/batman-adv
+endef
+
 MAKE_BATMAN_ADV_ARGS += \
 	CROSS_COMPILE="$(TARGET_CROSS)" \
 	KERNELPATH="$(LINUX_DIR)" \


### PR DESCRIPTION
The configuration file of batman-adv should be marked as such to avoid that the old configuration options are overwritten when it is upgraded.
