### PR TITLE
nodogsplash: migrate to uci based configuration

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
 PKG_VERSION:=0.9_beta9.9.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)/
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -45,8 +45,10 @@ define Package/nodogsplash/install
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) files/nodogsplash.init $(1)/etc/init.d/$(PKG_NAME)
 
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_CONF) ./files/nodogsplash.migrate $(1)/etc/uci-defaults/30_nodogsplash
+
 	$(INSTALL_DIR) $(1)/etc/$(PKG_NAME)/htdocs/images
-	$(CP) $(PKG_BUILD_DIR)/resources/nodogsplash.conf $(1)/etc/$(PKG_NAME)/
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.html $(1)/etc/$(PKG_NAME)/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/infoskel.html $(1)/etc/$(PKG_NAME)/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/$(PKG_NAME)/htdocs/images/

--- a/nodogsplash/files/nodogsplash.init
+++ b/nodogsplash/files/nodogsplash.init
@@ -2,6 +2,7 @@
 #
 # description: Startup/shutdown script for nodogsplash captive portal
 #
+# Alexander Couzens <lynxis@fe80.eu> 2014
 # P. Kube 2007
 #
 # (Based on wifidog startup script
@@ -17,32 +18,213 @@ USE_PROCD=1
 
 IPT=/usr/sbin/iptables
 WD_DIR=/usr/bin
-NDS_CONF=/etc/nodogsplash/nodogsplash.conf
 # -s -d 5 runs in background, with level 5 (not so verbose) messages to syslog
 # -f -d 7 runs in foreground, with level 7 (verbose) debug messages to terminal
 OPTIONS="-s -f -d 5"
+CONFIGFILE="/tmp/invalid_nodogsplash.conf"
+
+# nolog(loglevel message ...)
+nolog() {
+  local level=$1
+  shift
+  logger -s -t nodogsplash -p daemon.$level $@
+}
+
+# append_config_option <cfgfile> <uci_cfg_obj> <option_name> <config_counterpart> [<optional default>]
+# append "$config_counterpart $value" to cfgfile if option_name exists
+# e.g. append_config_option "$CONFIGFILE" "$cfg" bind_address BindAddress 0.0.0.0
+# will append "BindAddress 192.168.1.1" if uci bind_address is '192.168.1.1'
+append_config_option() {
+  local val=""
+  local cfg="$1"
+  local config_file="$2"
+  local option_name="$3"
+  local config_counterpart="$4"
+  local default="$5"
+  config_get val "$cfg" "$option_name" "$default"
+  [ -n "$val" ] && echo "" >> $config_file
+}
+
+setup_user_authentication() {
+  local cfg="$1"
+  local val
+
+  config_get_bool val "$cfg" authenticate_immediately 0
+  [ $val -gt 0 ] && echo "AuthenticateImmediately yes" >> $CONFIGFILE
+
+  config_get val "$cfg" username
+  if [ -n "${val}" ] ; then
+    echo "UsernameAuthentication" >> $CONFIGFILE
+    echo "Username ${val}" >> $CONFIGFILE
+  fi
+
+  config_get val "$cfg" password
+  if [ -n "${val}" ] ; then
+    echo "PasswordAuthentication" >> $CONFIGFILE
+    echo "Password ${val}" >> $CONFIGFILE
+  fi
+}
+
+setup_mac_lists() {
+  local cfg="$1"
+  local MAC=""
+  local val
+
+  append_mac() {
+    append MAC $1 ,
+  }
+
+  config_get val "$cfg" macmechanism
+  if [ -z "${val}" ] ; then
+    # check if we have AllowedMACList or BlockedMACList defined they will be ignored
+    config_get val "$cfg" allowedmac
+    if [ -n "${val}" ] ; then
+      echo "Ignoring allowedmac - macmechanism not \"allow\"" >&2
+    fi
+
+    config_get val "$cfg" blockedmac
+    if [ -n "${val}" ] ; then
+      echo "Ignoring blockedmac - macmechanism not \"block\"" >&2
+    fi
+  elif [ "${val}" == "allow" ] ; then
+    MAC=""
+    config_list_foreach "$cfg" allowedmac append_mac
+    echo "AllowedMACList $MAC" >> $CONFIGFILE
+  elif [ "${val}" == "block" ] ; then
+    MAC=""
+    config_list_foreach "$cfg" blockedmac append_mac
+    echo "BlockedMACList $MAC" >> $CONFIGFILE
+  else
+    nolog error "$cfg Invalid macmechanism '$val' - allow or block are valid."
+    return 1
+  fi
+  MAC=""
+  config_list_foreach "$cfg" trustedmac append_mac
+  [ -n "$MAC" ] && echo "TrustedMACList $MAC" >> $CONFIGFILE
+}
+
+setup_firewall() {
+  local cfg="$1"
+  local uciname
+  local val
+
+  append_firewall() {
+    echo "    FirewallRule $1" >> $CONFIGFILE
+  }
+
+  for rule in $(echo authenticated-users preauthenticated-users users-to-router trusted-users trusted-users-to-router)
+  do
+    uci_name=${rule//-/_}
+    # uci does not allow - dashes
+    echo "FirewallRuleSet $rule {" >> $CONFIGFILE
+    config_list_foreach "$cfg" ${uci_name} append_firewall
+    echo "}" >> $CONFIGFILE
+    config_get val "$cfg" policy_${uci_name}
+    [ -n "${val}" ] && echo "EmptyRuleSetPolicy $rule $val" >> $CONFIGFILE
+  done
+}
+
+generate_uci_config() {
+  local cfg="$1"
+  local val
+  local ifname
+  local download
+  local upload
+
+  CONFIGFILE="/tmp/etc/nodogsplash_$cfg.conf"
+
+  echo "# auto-generated config file from /etc/config/nodogsplash" > $CONFIGFILE
+  config_get val "$cfg" network
+  if [ ! -n "${val}" ] ; then
+    nolog error "$cfg missing network"
+    return 1
+  fi
+
+  if ! network_get_device ifname $val ; then
+    nolog error "$cfg can not find ifname for network '${val}'"
+    return 1
+  fi
+
+  echo "GatewayInterface $ifname" >> $CONFIGFILE
+  config_get val "$cfg" externalnetwork
+  [ -n "${val}" ] && network_get_device ifname ${val} && echo "ExternalInterface $ifname" >> $CONFIGFILE
+
+  append_config_option "$CONFIGFILE" "$cfg" gatewayname GatewayName
+  append_config_option "$CONFIGFILE" "$cfg" gatewayaddress GatewayAddress
+  append_config_option "$CONFIGFILE" "$cfg" gatewayport GatewayPort
+  append_config_option "$CONFIGFILE" "$cfg" maxclients MaxClients
+  append_config_option "$CONFIGFILE" "$cfg" imagedir ImagesDir
+  append_config_option "$CONFIGFILE" "$cfg" redirecturl RedirectURL
+  append_config_option "$CONFIGFILE" "$cfg" clientidletimeout ClientIdleTimeout
+  append_config_option "$CONFIGFILE" "$cfg" clientforcetimeout ClientForceTimeout
+  append_config_option "$CONFIGFILE" "$cfg" gatewayiprange GatewayIPRange
+  append_config_option "$CONFIGFILE" "$cfg" passwordattempts PasswordAttempts
+  append_config_option "$CONFIGFILE" "$cfg" macmechanism MACMechanism
+  append_config_option "$CONFIGFILE" "$cfg" uploadlimit UploadLimit
+  append_config_option "$CONFIGFILE" "$cfg" downloadlimit DownloadLimit
+
+  config_get download "$cfg" downloadlimit
+  config_get upload "$cfg" uploadlimit
+  [ -n "$upload" -o -n "$download" ] && echo "TrafficControl yes" >> $CONFIGFILE
+
+  setup_mac_lists "$cfg"
+  setup_user_authentication "$cfg"
+  setup_firewall "$cfg"
+}
+
+# setup configuration and start instance
+create_instance() {
+  local cfg="$1"
+  local manual_config
+  local val
+  CONFIGFILE="/tmp/etc/nodogsplash_$cfg.conf"
+
+  config_get_bool val "$cfg" disabled 0
+  [ $val -gt 0 ] && return 0
+
+  config_get manual_config "$cfg" config ""
+  if [ ! -n "$manual_config" ] ; then
+    generate_uci_config "$cfg"
+  else
+    # check if configration exists
+    if [ ! -f "$manual_config" ] ; then
+      nolog error "Configuration file '$file' doesn't exists"
+      return 0
+    fi
+    CONFIGFILE="$manual_config"
+  fi
+
+  if ! test_module ;  then
+    logger -s -t nodogsplash -p daemon.error "nodogsplash is missing some kernel modules"
+  fi
+
+  procd_open_instance $cfg
+  procd_set_param command /usr/bin/nodogsplash -c $CONFIGFILE $OPTIONS
+  procd_set_param respawn
+  procd_set_param file $CONFIGFILE
+  procd_close_instance
+}
 
 start_service() {
-	if test_module ;  then
-		procd_open_instance
-		procd_set_param command /usr/bin/nodogsplash $OPTIONS
-		procd_set_param respawn
-		procd_close_instance
-	else
-		logger -s -t nodogsplash -p daemon.error "nodogsplash is missing some kernel modules"
-	fi
+  include /lib/functions
+
+  mkdir -p /tmp/etc/
+  config_load nodogsplash
+
+  config_foreach create_instance instance
 }
 
 stop_service() {
-	# nodogsplash doesn't exit fast enought, when procd terminates it.
-	# otherwise procd will restart nodogsplash twice. first time starting nodogsplash fails, second time it succeeds
-	sleep 1
+  # nodogsplash doesn't exit fast enought, when procd terminates it.
+  # otherwise procd will restart nodogsplash twice. first time starting nodogsplash fails, second time it succeeds
+  sleep 1
 }
 
 status() {
-	$WD_DIR/ndsctl status
+  $WD_DIR/ndsctl status
 }
 
+# Test if we got all modules loaded
 test_module() {
 
     ### Test ipt_mark with iptables

--- a/nodogsplash/files/nodogsplash.migrate
+++ b/nodogsplash/files/nodogsplash.migrate
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+add_uci_default() {
+  local disabled=$1
+
+# add default configuration
+  uci batch <<EOF
+add nodogsplash instance
+set nodogsplash.@instance[-1].network='lan'
+set nodogsplash.@instance[-1].gatewayname='OpenWrt Nodogsplash'
+set nodogsplash.@instance[-1].maxclients=250
+set nodogsplash.@instance[-1].idletimeout=1200
+set nodogsplash.@instance[-1].disabled=$disabled
+add_list nodogsplash.@instance[-1].users_to_router='allow tcp port 22'
+add_list nodogsplash.@instance[-1].users_to_router='allow tcp port 23'
+add_list nodogsplash.@instance[-1].users_to_router='allow tcp port 53'
+add_list nodogsplash.@instance[-1].users_to_router='allow udp port 53'
+add_list nodogsplash.@instance[-1].users_to_router='allow udp port 67'
+add_list nodogsplash.@instance[-1].users_to_router='allow tcp port 80'
+add_list nodogsplash.@instance[-1].users_to_router='allow tcp port 443'
+EOF
+
+}
+
+[ -e /etc/config/nodogsplash ] && exit 0
+
+touch /etc/config/nodogsplash
+
+# check if we have an old config
+if [ -e "/etc/nodogsplash/nodogsplash.conf" ] ; then
+
+  uci batch <<EOF
+add nodogsplash instance
+set nodogsplash.@instance[-1].config='/etc/nodogsplash/nodogsplash.conf'
+EOF
+
+  add_uci_default 1
+else
+  add_uci_default 0
+fi
+
+exit 0


### PR DESCRIPTION
Use /etc/config/nodogsplash for configuration.
Old setups will migrate using config option to use old
file base configuration.