### PR TITLE
miniupnpd: fix error message during shutdown

### DIFF
--- a/miniupnpd/files/miniupnpd.init
+++ b/miniupnpd/files/miniupnpd.init
@@ -2,6 +2,7 @@
 # Copyright (C) 2006-2011 OpenWrt.org
 
 START=95
+STOP=15
 
 SERVICE_USE_PID=1
 


### PR DESCRIPTION
During shutdown, miniupnpd is stopped after network. Because of this,
miniupnpd is unable to broadcast good-bye notifications, and displays an
error message. Stop miniupnpd before netifd to solve this.

Signed-off-by: Stijn Tintel stijn@linux-ipv6.be
