### PR TITLE
bird: bump to 1.4.5

### DIFF
--- a/bird/Makefile
+++ b/bird/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird
-PKG_VERSION:=1.4.3
+PKG_VERSION:=1.4.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_MD5SUM:=eb7e00b9c1d102ddfcbc19d9cb168511
+PKG_MD5SUM:=a8e5e0a9129ce30fe6102c593bafb763
 PKG_BUILD_DEPENDS:=libncurses libreadline
 PKG_LICENSE:=GPL-2.0
 


### PR DESCRIPTION
Signed-off-by: Stijn Tintel stijn@linux-ipv6.be
