### PR TITLE
[olsrd] adapt init script for 0.6.8 (PingCmd option)

### DIFF
--- a/olsrd/files/olsrd.init
+++ b/olsrd/files/olsrd.init
@@ -38,7 +38,7 @@ validate_varname() {
 
 validate_olsrd_option() {
 	local str="$1"
-	[ -z "$str" -o "$str" != "${str%%[! 	0-9A-Za-z./|:_-]*}" ] && return 1
+	[ -z "$str" -o "$str" != "${str%%[! 	0-9A-Za-z.%/|:_-]*}" ] && return 1
 	return 0
 }
 


### PR DESCRIPTION
olsrd 0.6.8 accepts a PingCmd parameter as of
http://olsr.org/git/?p=olsrd.git;a=commitdiff;h=0a26c52af3941eb9060b193cae5552f8d13fd28e.
The PingCmd is a string of the form "ping -c 1 -q %s" where %s is
replaced with an IP. This commit allows for '%' characters in an olsrd
option.