### PR TITLE
mcproxy: uci config improvements and fixes

### DIFF
--- a/mcproxy/Makefile
+++ b/mcproxy/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014 OpenWrt.org
+# Copyright (C) 2014-2015 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=mcproxy
 PKG_SOURCE_VERSION:=b7bd2d0809a0d1f177181c361b9a6c83e193b79a
 PKG_VERSION:=2014-12-31-$(PKG_SOURCE_VERSION)
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=git://github.com/mcproxy/mcproxy.git

--- a/mcproxy/files/mcproxy.init
+++ b/mcproxy/files/mcproxy.init
@@ -1,26 +1,8 @@
 #!/bin/sh /etc/rc.common
-# Copyright (C) 2014 OpenWrt.org
+# Copyright (C) 2014-2015 OpenWrt.org
 
-START=50
+START=99
 USE_PROCD=1
-
-# mcproxy_list_iface <var> <section> <option>
-mcproxy_list_iface() {
-	local val
-	local len
-	local _buffer
-	local c=1
-
-	config_get len "$2" "${3}_LENGTH"
-	[ -z "$len" ] && return 0
-	while [ $c -le "$len" ]; do
-		config_get val "$2" "${3}_ITEM$c"
-		append _buffer "\"${val}\""
-		c="$(($c + 1))"
-	done
-
-	export "${1}=${_buffer}";
-}
 
 mcproxy_handle_instances() {
 	local instance="$1"
@@ -28,20 +10,36 @@ mcproxy_handle_instances() {
 	local disabled
 	local pre=""
 	local name
-	local upstream
-	local downstream
+	local upstreams
+	local downstreams
 
 	config_get_bool disabled "$instance" 'disabled' '0'
 	config_get name "$instance" "name" "$instance"
-	mcproxy_list_iface upstream "$instance" "upstream"
-	mcproxy_list_iface downstream "$instance" "downstream"
+	config_get upstreams "$instance" "upstream"
+	config_get downstreams "$instance" "downstream"
 
 	if [ $disabled -eq 1 ]; then
 		pre="# "
 	fi
 
-	if [ ! -z $upstream ] && [ ! -z $downstream ]; then
-		echo -e "${pre}pinstance ${name}: ${upstream} ==> ${downstream};\n" >> $conf_file
+	local str_up=""
+	if [ -n "$upstreams" ]; then
+		local upstream
+		for upstream in $upstreams; do
+			str_up="$str_up \"$upstream\""
+		done
+	fi
+
+	local str_down=""
+	if [ -n "$downstreams" ]; then
+		local downstream
+		for downstream in $downstreams; do
+			str_down="$str_down \"$downstream\""
+		done
+	fi
+
+	if [ ! -z $downstream ]; then
+		echo -e "${pre}pinstance ${name}:${str_up} ==>${str_down};\n" >> $conf_file
 	fi
 }
 
@@ -66,16 +64,14 @@ mcproxy_list_table() {
 mcproxy_handle_tables() {
 	local table="$1"
 	local conf_file="$2"
-	local table_name
-	local table_entries
+	local name
+	local entries
 
-	config_get table_name "$table" "name" ""
-	mcproxy_list_table table_entries "$table" "entries"
+	config_get name "$table" "name" ""
+	mcproxy_list_table entries "$table" "entries"
 
 	if [ ! -z $name ] && [ ! -z $table ]; then
-		echo -e "table $table_name {\n" >> $conf_file
-		echo -e "$table_entries\n" >> $conf_file
-		echo -e "};\n" >> $conf_file
+		echo -e "table $name {\n${entries}};\n" >> $conf_file
 	fi
 }
 
@@ -126,7 +122,17 @@ mcproxy_handle_behaviour() {
 		pre="# "
 	fi
 
-	echo -e "${pre}pinstance $instance $section $interface $direction $rule_table;\n" >> $conf_file
+	echo -e "${pre}pinstance $instance $section \"$interface\" $direction $rule_table;\n" >> $conf_file
+}
+
+mcproxy_network_trigger() {
+	procd_add_interface_trigger "interface.*" "$1" /etc/init.d/mcproxy restart
+}
+mcproxy_handle_network() {
+	local instance="$1"
+
+	config_list_foreach "$instance" upstream mcproxy_network_trigger
+	config_list_foreach "$instance" downstream mcproxy_network_trigger
 }
 
 start_instance() {
@@ -139,6 +145,7 @@ start_instance() {
 
 	config_get conf_file "$cfg" "file"
 	if [ ! -n "$conf_file" ]; then
+		mkdir -p /var/etc
 		conf_file="/var/etc/mcproxy_${cfg}.conf"
 
 		local protocol
@@ -158,11 +165,17 @@ start_instance() {
 	config_get_bool aux "$cfg" 'respawn' '0'
 	[ "$aux" = 1 ] && procd_set_param respawn
 
+	procd_open_trigger
+	config_foreach mcproxy_handle_network instance
+	procd_close_trigger
+
 	procd_close_instance
 }
 
-service_triggers() { 
-	procd_add_reload_trigger "mcproxy" 
+service_triggers() {
+	procd_open_trigger
+	procd_add_config_trigger "config.change" "mcproxy" /etc/init.d/mcproxy restart
+	procd_close_trigger
 }
 
 start_service() {


### PR DESCRIPTION
- fix /var/etc race condition (uci config)
- start mcproxy later
- rework mcproxy config trigger
- add network triggers
- simplify uci instances generation and allow querier only configs
- improve uci tables generation
- fix uci behaviour generation for specific interface names

Signed-off-by: Álvaro Fernández Rojas <noltari@gmail.com>