### PR TITLE
Some uci defaults fixes

### DIFF
--- a/cjdns/files/cjdns.defaults
+++ b/cjdns/files/cjdns.defaults
@@ -18,7 +18,7 @@ EOF
 
   # make sure config is present (might fail for any reason)
   uci get cjdns.cjdns.ipv6 >/dev/null 2>&1
-  if [ $? -ne 0]; then
+  if [ $? -ne 0 ]; then
     exit 1
   fi
 

--- a/cjdns/files/cjdns.defaults
+++ b/cjdns/files/cjdns.defaults
@@ -22,22 +22,24 @@ EOF
     exit 1
   fi
 
-  # enable auto-peering on ethernet
-  uci show network.lan | grep bridge >/dev/null 2>&1
+  # enable auto-peering on ethernet interface lan, if existing
+  uci get network.lan | grep interface >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    # most routers will set up an ethernet bridge for the lan
-    ifname="br-lan"
-  else
-    # docker containers don't have permission to create bridges by default,
-    # so we bind to the underlying interface instead (likely eth0)
-    ifname=`uci get network.lan.ifname`
-  fi
-  uci -q batch <<-EOF >/dev/null
-    add cjdns eth_interface
-    set cjdns.@eth_interface[-1].beacon=2
-    set cjdns.@eth_interface[-1].bind=$ifname
+    uci get network.lan.type | grep bridge >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      # most routers will set up an ethernet bridge for the lan
+      ifname="br-lan"
+    else
+      # docker containers don't have permission to create bridges by default,
+      # so we bind to the underlying interface instead (likely eth0)
+      ifname=`uci get network.lan.ifname`
+    fi
+    uci -q batch <<-EOF >/dev/null
+      add cjdns eth_interface
+      set cjdns.@eth_interface[-1].beacon=2
+      set cjdns.@eth_interface[-1].bind=$ifname
 EOF
-
+  fi
   # set the tun interface name
   uci set cjdns.cjdns.tun_device=tuncjdns
 


### PR DESCRIPTION
rant-mode=on: Generally, Linux interface names should not leak into uci, uci interfaces should be used instead (i.e. lan instead of eth0 or br-lan)
cjdrouteconf should query this from netifd via ubus similar to
ubus call network.interface status "{ \"interface\" : \"lan\" }"
