### PR TITLE
babeld: Added missing $IPKG_INSTROOT

### DIFF
--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-. /lib/functions/network.sh
+. $IPKG_INSTROOT/lib/functions/network.sh
 
 START=70
 


### PR DESCRIPTION
Without this automatic init script activation in imagebuilder fails.