### PR TITLE
Fix cjdns build on mac

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -20,9 +20,9 @@ PKG_NAME:=cjdns
 PKG_VERSION:=0.16
 PKG_RELEASE:=14
 
-PKG_SOURCE_URL:=https://github.com/hyperboria/cjdns.git
+PKG_SOURCE_URL:=https://github.com/cjdelisle/cjdns.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=a97c189b9181bf83ed44a9ab0ebc817882c60ffa
+PKG_SOURCE_VERSION:=a2d58009129ec2633c8dda45fc62196d7add5ee6
 PKG_LICENSE:=GPL-3.0
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.bz2
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_SOURCE_VERSION)
@@ -79,11 +79,14 @@ endif
 define Build/Compile
 	CROSS="true" \
 	CC="$(TARGET_CC)" \
+	AR="$(TARGET_AR)" \
+	RANLIB="$(TARGET_RANLIB)" \
 	CFLAGS="$(TARGET_CFLAGS)" \
 	LDFLAGS="$(TARGET_LDFLAGS)" \
 	SYSTEM="linux" \
 	TARGET_ARCH="$(CONFIG_ARCH)" \
 	SSP_SUPPORT="$(CONFIG_SSP_SUPPORT)" \
+	GYP_ADDITIONAL_ARGS="-f make-linux" \
 	$(PKG_DO_VARS) \
 	$(PKG_BUILD_DIR)/do
 endef


### PR DESCRIPTION
Fixes 2 bugs in the build which only appear when building on a mac.
1. ar and ranlib are not specified so the platform ones are used by nacl build ... which happens to work on linux but not on mac
2. unless make-linux is explicitly specified as the build format, GYP will attempt to build an xcode project which breaks libuv build.