### PR TITLE
alfred: not only wait for the interface, but also a link-local address

### DIFF
--- a/alfred/files/alfred.init
+++ b/alfred/files/alfred.init
@@ -37,6 +37,31 @@ wait_for_dir()
 	fi
 }
 
+wait_for_ll_address()
+{
+	local iface="$1"
+	local timeout=30
+
+	echo "${initscript}: waiting $timeout secs for $iface address..."
+	for i in $(seq $timeout); do
+		# We look for
+		# - the link-local address (starts with fe80)
+		# - without tentative flag (bit 0x40 in the flags field; the first char of the flags field begins 38 columns after the fe80 prefix
+		# - on interface $iface
+		if awk '
+			BEGIN { RET=1 }
+			/^fe80.{37} [012389ab]/ { if ($6 == "'"$iface"'") RET=0 }
+			END { exit RET }
+		' /proc/net/if_inet6; then
+			return
+		fi
+		sleep 1
+	done
+
+	echo "${initscript}: $iface address not detected, alfred not starting."
+	exit 1
+}
+
 alfred_start()
 {
 	local args=""
@@ -62,7 +87,7 @@ alfred_start()
 		wait_for_dir "$batmanif" "/sys/class/net/$batmanif/mesh"
 	fi
 
-	wait_for_dir "$interface" "/sys/class/net/$interface/"
+	wait_for_ll_address "$interface"
 
 	append alfred_args "$args"
 	enable=1


### PR DESCRIPTION
Changes between alfred 2015.0 and 2015.1 cause alfred to print an error
and exit when the interface to bind to is not completely set up (has no
non-tentative link-local address). As a workaround, wait for such an
address by reading /proc/net/if_inet6 before alfred is started.

In the long term, it would be nice to make alfred more robust against
missing interfaces (allowing alfred to start without the interface
existing, and keeping it working even when the interface is removed and
re-added while alfred is running).

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>