### PR TITLE
babeld: fix parsing of list import_table

### DIFF
--- a/babeld/files/babeld.config
+++ b/babeld/files/babeld.config
@@ -16,8 +16,6 @@ config general
 	## Enable ipv6-subtrees by default since OpenWrt should ship with a
 	## recent enough kernel for it to work.
 	option 'ipv6_subtrees' 'true'
-	## This seems somewhat buggy on BB.  If you need only one
-	## import-table statement, "option import_table 42" should work.
 	# list 'import_table' '42'
 	# list 'import_table' '100'
 	## Alternative configuration file and directory.

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -166,6 +166,9 @@ babel_config_cb() {
 			local value="$2"
 			# Ignore old options
 			list_contains ignored_options "$option" && return
+			# Skip lists. They will be taken care of by list_cb
+			test "${option#*_ITEM}" != "$option" && return
+			test "${option#*_LENGTH}" != "$option" && return
 			cfg_append "${option//_/-} $value"
 		}
 	;;


### PR DESCRIPTION
When parsing list options using config_load option_cb will be called
with additional options ending in _ITEM$x and _LENGTH. This ignores any
option containing _LENGTH or _ITEM as they can't possible be a valid
babeld option making a config like

    config general
        list import_table 23
        list import_table 42

work.

Signed-off-by: Nils Schneider <nils@nilsschneider.net>