### PR TITLE
bird: explicitly set C standard

### DIFF
--- a/bird/Makefile
+++ b/bird/Makefile
@@ -161,6 +161,8 @@ endef
 
 CONFIGURE_ARGS += --with-linux-headers="$(LINUX_DIR)"
 
+TARGET_CFLAGS+=-std=gnu89
+
 define Build/Template
 
 $(STAMP_BUILT)-$(2): $(STAMP_PREPARED)


### PR DESCRIPTION
fixes gcc5 compile

compile error was:
cf-lex.o: In function `add_tail':
cf-lex.c:(.text+0x2d1): multiple definition of `add_tail'
cf-parse.tab.o:cf-parse.tab.c:(.text+0x1f9): first defined here

Signed-off-by: Dirk Neukirchen <dirkneukirchen@web.de>