### PR TITLE
Fix cjdns

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -20,7 +20,7 @@ PKG_NAME:=cjdns
 PKG_VERSION:=0.17
 PKG_RELEASE:=1
 
-PKG_SOURCE_URL:=https://github.com/hyperboria/cjdns.git
+PKG_SOURCE_URL:=git://github.com/hyperboria/cjdns.git
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=1cf53a812a9b19e5ce883c16d40ac183f61d43f6
 PKG_LICENSE:=GPL-3.0


### PR DESCRIPTION
Currently cjdns is not in the openwrt-routing snapshots feed: http://downloads.openwrt.org/snapshots/trunk/ar71xx/generic/packages/routing/

When I tried to build cjdns from this repo I got this error:
```
/usr/local/src/OpenWrt-SDK-ar71xx-generic_gcc-5.2.0_musl-1.1.11.Linux-x86_64/build_dir/target-mips_34kc_musl-1.1.11/cjdns-1cf53a812a9b19e5ce883c16d40ac183f61d43f6/node_build/GetVersion.js:11
            throw new Error("git error: " + data);
            ^

Error: git error: fatal: Not a git repository (or any of the parent directories): .git

    at Socket.<anonymous> (/usr/local/src/OpenWrt-SDK-ar71xx-generic_gcc-5.2.0_musl-1.1.11.Linux-x86_64/build_dir/target-mips_34kc_musl-1.1.11/cjdns-1cf53a812a9b19e5ce883c16d40ac183f61d43f6/node_build/GetVersion.js:11:19)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:146:16)
    at Socket.Readable.push (_stream_readable.js:110:10)
    at Pipe.onread (net.js:523:20)
Makefile:145: recipe for target '/usr/local/src/OpenWrt-SDK-ar71xx-generic_gcc-5.2.0_musl-1.1.11.Linux-x86_64/build_dir/target-mips_34kc_musl-1.1.11/cjdns-1cf53a812a9b19e5ce883c16d40ac183f61d43f6/.built' failed
make[2]: *** [/usr/local/src/OpenWrt-SDK-ar71xx-generic_gcc-5.2.0_musl-1.1.11.Linux-x86_64/build_dir/target-mips_34kc_musl-1.1.11/cjdns-1cf53a812a9b19e5ce883c16d40ac183f61d43f6/.built] Error 1
```
So cjdns is depending on being in a git repo to build properly. By changing the makefile to get cjdns using git instead of https, it is downloaded into a git repo and builds without issue.