### PR TITLE
fix quoting of daemon name

### DIFF
--- a/oonf-init-scripts/files/oonf_hotplug.sh
+++ b/oonf-init-scripts/files/oonf_hotplug.sh
@@ -3,7 +3,7 @@
 case "${ACTION}" in
 	ifup)
 		. /etc/rc.common /etc/init.d/${DAEMON} enabled && {
-			logger -t '${DAEMON}[hotplug]' -p daemon.info 'reloading configuration'
+			logger -t "${DAEMON}[hotplug]" -p daemon.info 'reloading configuration'
 			. /etc/rc.common /etc/init.d/${DAEMON} reload
 		}
 	;;


### PR DESCRIPTION
The current quoting did not allow substitution and resulted in log messages with
the prefix "${DAEMON}[hotplug]".