### PR TITLE
hnetd: support the ip4mode parameter

### DIFF
--- a/hnetd/files/hnet.config
+++ b/hnetd/files/hnet.config
@@ -11,6 +11,7 @@ config security security
 
 config pa pa
 #	option ip4prefix 10.0.0.0/8
+#	option ip4mode ifuplink
 #	option ulaprefix fd12:3456:789A::/48
 #	option ulamode off
 #	option persistent_store /etc/hnet-pa.store

--- a/hnetd/files/hnetd.init
+++ b/hnetd/files/hnetd.init
@@ -83,6 +83,9 @@ start_service() {
     config_get val pa ip4prefix
     [ -n "$val" ] && procd_append_param command --ip4prefix $val
 
+    config_get val pa ip4mode
+    [ -n "$val" ] && procd_append_param command --ip4mode $val
+
     config_get val pa ulaprefix
     [ -n "$val" ] && procd_append_param command --ulaprefix $val
 


### PR DESCRIPTION
Add support for setting the `ip4mode` parameter (sbyx/hnetd@2953f5a) in
the `config pa pa` stanza of `/etc/config/hnet`.