### PR TITLE
hnetd: ensure ULA prefix persists across reboots

### DIFF
--- a/hnetd/files/hnet.config
+++ b/hnetd/files/hnet.config
@@ -13,7 +13,7 @@ config pa pa
 #	option ip4prefix 10.0.0.0/8
 #	option ulaprefix fd12:3456:789A::/48
 #	option ulamode off
-#	option persistent_store /etc/hnet-pa.store
+	option persistent_store /etc/hnet-pa.store
 
 config sd sd
 #	option router_name openwrt


### PR DESCRIPTION
Quoting from [RFC 7084](https://tools.ietf.org/html/rfc7084#section-4.3):

> ULA-2:  An IPv6 CE router with a ULA prefix MUST maintain this prefix consistently across reboots.

Fixes sbyx/hnetd#52.