### PR TITLE
bird: fix mips64, bump to 1.6.0

### DIFF
--- a/bird/Makefile
+++ b/bird/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2009-2015 OpenWrt.org
+# Copyright (C) 2009-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird
-PKG_VERSION:=1.5.0
-PKG_RELEASE:=2
+PKG_VERSION:=1.6.0
+PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_MD5SUM:=330bde6372afa106abfe5a9737e471c1
+PKG_MD5SUM:=4c92ec3548a2a120243879b6ef7046dd
 PKG_BUILD_DEPENDS:=libncurses libreadline
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 

--- a/bird/Makefile
+++ b/bird/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird
 PKG_VERSION:=1.5.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird

--- a/bird/patches/001-netlink-update-struct-msghdr.patch
+++ b/bird/patches/001-netlink-update-struct-msghdr.patch
@@ -1,0 +1,49 @@
+From 31e9e10144a6994773a04d94903fa3bdde6de91e Mon Sep 17 00:00:00 2001
+From: Stijn Tintel <stijn@linux-ipv6.be>
+Date: Tue, 10 May 2016 16:45:35 +0300
+Subject: [PATCH] netlink: update struct msghdr
+
+The netlink code assumes an order for the members of struct msghdr.
+This breaks recvmsg and sendmsg with musl libc on mips64. Fix this by
+using designated initializers instead.
+
+Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>
+---
+ sysdep/linux/netlink.c | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/sysdep/linux/netlink.c b/sysdep/linux/netlink.c
+index 1ffdff0..b42e7b6 100644
+--- a/sysdep/linux/netlink.c
++++ b/sysdep/linux/netlink.c
+@@ -125,7 +125,12 @@ nl_get_reply(struct nl_sock *nl)
+ 	{
+ 	  struct iovec iov = { nl->rx_buffer, NL_RX_SIZE };
+ 	  struct sockaddr_nl sa;
+-	  struct msghdr m = { (struct sockaddr *) &sa, sizeof(sa), &iov, 1, NULL, 0, 0 };
++	  struct msghdr m = {
++	    .msg_name = &sa,
++	    .msg_namelen = sizeof(sa),
++	    .msg_iov = &iov,
++	    .msg_iovlen = 1,
++	  };
+ 	  int x = recvmsg(nl->fd, &m, 0);
+ 	  if (x < 0)
+ 	    die("nl_get_reply: %m");
+@@ -1231,7 +1236,12 @@ nl_async_hook(sock *sk, int size UNUSED)
+ {
+   struct iovec iov = { nl_async_rx_buffer, NL_RX_SIZE };
+   struct sockaddr_nl sa;
+-  struct msghdr m = { (struct sockaddr *) &sa, sizeof(sa), &iov, 1, NULL, 0, 0 };
++  struct msghdr m = {
++    .msg_name = &sa,
++    .msg_namelen = sizeof(sa),
++    .msg_iov = &iov,
++    .msg_iovlen = 1,
++  };
+   struct nlmsghdr *h;
+   int x;
+   uint len;
+-- 
+2.7.3
+


### PR DESCRIPTION
* Fix recvmsg/sendmsg on mips64
* Bump to 1.6.0