### PR TITLE
batman-adv: remove DEPENDS:=kmod-crypto-core

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -27,7 +27,7 @@ define KernelPackage/batman-adv
   URL:=https://www.open-mesh.org/
   MAINTAINER:=Marek Lindner <mareklindner@neomailbox.ch>
   SUBMENU:=Network Support
-  DEPENDS:=+KMOD_BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-crypto-core +kmod-crypto-crc32c +kmod-lib-crc32c +kmod-cfg80211
+  DEPENDS:=+KMOD_BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-crypto-crc32c +kmod-lib-crc32c +kmod-cfg80211
   TITLE:=B.A.T.M.A.N. Adv
   FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoLoad,50,cfg80211 batman-adv)


### PR DESCRIPTION
kmod-crypto-core was removed in openwrt/trunk svn 46820 and all
kconfig's are now built-in.

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>