### PR TITLE
cjdns: use temporary directory within the build environment

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=cjdns
 PKG_VERSION:=0.17
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://github.com/hyperboria/cjdns.git
 PKG_SOURCE_PROTO:=git
@@ -77,6 +77,7 @@ PKG_DO_VARS+= UCLIBC=1
 endif
 
 define Build/Compile
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)/tmp
 	CROSS="true" \
 	CC="$(TARGET_CC)" \
 	AR="$(TARGET_AR)" \
@@ -87,6 +88,7 @@ define Build/Compile
 	TARGET_ARCH="$(CONFIG_ARCH)" \
 	SSP_SUPPORT="$(CONFIG_SSP_SUPPORT)" \
 	GYP_ADDITIONAL_ARGS="-f make-linux" \
+	CJDNS_BUILD_TMPDIR="$(PKG_BUILD_DIR)/tmp" \
 	$(PKG_DO_VARS) \
 	$(PKG_BUILD_DIR)/do
 endef


### PR DESCRIPTION
By default, cjdns' build system uses the system wide `/tmp` directory to store
intermediate build artifacts.

Unfortunately its build system fails to clean after itself, leaving thousands
of `jsmake-<hash>` directories behind, taking up precious inodes and massively
slowing down processes traversing the temporary directory:

    root@buildbot:~# find /tmp/ -maxdepth 1 -type d -name 'jsmake-*' | wc -l
    1581

Attempt to solve that problem by using the upstream-introduced
`CJDNS_BUILD_TMPDIR` environment variable in order to move the intermediate
artifacts from the system-wide `/tmp` to a temporary directory within the
package build dir which is properly deleted upon package rebuild cycles.

Signed-off-by: Jo-Philipp Wich <jo@mein.io>