### PR TITLE
nat46: Depend on IPV6 as IPv6 is kernel builtin module now

### DIFF
--- a/nat46/Makefile
+++ b/nat46/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=nat46
-PKG_VERSION:=6
+PKG_VERSION:=7
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
@@ -37,7 +37,7 @@ define Package/464xlat
 endef
 
 define KernelPackage/nat46
-  DEPENDS:=+kmod-ipv6
+  DEPENDS:=@IPV6
   TITLE:=Stateless NAT46 translation kernel module
   SECTION:=kernel
   SUBMENU:=Network Support


### PR DESCRIPTION
Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>