### PR TITLE
miniupnpd: add igd2 postrouting table

### DIFF
--- a/miniupnpd/Makefile
+++ b/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://miniupnp.free.fr/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/miniupnpd/files/firewall.include
+++ b/miniupnpd/files/firewall.include
@@ -5,6 +5,7 @@ IP6TABLES=/usr/sbin/ip6tables
 
 iptables -t filter -N MINIUPNPD 2>/dev/null
 iptables -t nat -N MINIUPNPD 2>/dev/null
+iptables -t nat -N MINIUPNPD-POSTROUTING 2>/dev/null
 
 [ -x $IP6TABLES ] && $IP6TABLES -t filter -N MINIUPNPD 2>/dev/null
 
@@ -20,6 +21,7 @@ add_extzone_rules() {
     # IPv4 - due to NAT, need to add both to nat and filter table
     iptables -t filter -I zone_${ext_zone}_forward -j MINIUPNPD
     iptables -t nat -I zone_${ext_zone}_prerouting -j MINIUPNPD
+    iptables -t nat -I zone_${ext_zone}_postrouting -j MINIUPNPD-POSTROUTING
 
     # IPv6 if available - filter only
     [ -x $IP6TABLES ] && {


### PR DESCRIPTION
add MINIUPNPD-POSTROUTING rule. Solves following error

addmasqueraderule() : chain MINIUPNPD-POSTROUTING not found

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>