### PR TITLE
batman-adv: Exchange include order for uapi header files

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -62,10 +62,10 @@ PKG_EXTRA_CFLAGS:= \
 
 NOSTDINC_FLAGS = \
 	-I$(PKG_BUILD_DIR)/net/batman-adv \
-	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
 	-I$(STAGING_DIR)/usr/include/mac80211-backport \
-	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
 	-I$(STAGING_DIR)/usr/include/mac80211 \
+	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
 	-include backport/backport.h \
 	-include $(PKG_BUILD_DIR)/compat-hacks.h
 


### PR DESCRIPTION
The build of netlink.c in batman-adv 2016.3 will fail because the definition of GENL_NAMESIZE and similar things are missing. This is is caused by an incorrect order of backports and non-backports header files mixed up with uapi and non-uapi header files. Parts of the header files would not get included by include_next because it not anymore in the remaining search paths.