### PR TITLE
batman-adv: move CONFIG_MODULE_STRIPPED hack to compat-hacks.h

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -11,7 +11,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=batman-adv
 
 PKG_VERSION:=2016.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_MD5SUM:=dd1ab664475902fc3dbf34998bbe5a90
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -83,8 +83,6 @@ endef
 define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(CP) ./files/compat-hacks.h $(PKG_BUILD_DIR)/
-	$(SED) '/#define _NET_BATMAN_ADV_MAIN_H_/a\#undef CONFIG_MODULE_STRIPPED' \
-		$(PKG_BUILD_DIR)/net/batman-adv/main.h
 endef
 
 define Build/Clean

--- a/batman-adv/files/compat-hacks.h
+++ b/batman-adv/files/compat-hacks.h
@@ -1,5 +1,7 @@
 /* Please avoid adding hacks here - instead add it to mac80211/backports.git */
 
+#undef CONFIG_MODULE_STRIPPED
+
 #include <linux/version.h>	/* LINUX_VERSION_CODE */
 #include <linux/types.h>
 


### PR DESCRIPTION
The CONFIG_MODULE_STRIPPED hack broke some time ago, as it is undefined too
late (after the headers using it have been included by compat-hacks.h).

Undefine CONFIG_MODULE_STRIPPED at the top of compat-hacks.h instead to
make the module version available to batctl again.

Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>

@lindnermarek