### PR TITLE
miniupnpd: fix local variables in hotplug script, change startup priority slightly

### DIFF
--- a/miniupnpd/Makefile
+++ b/miniupnpd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
 PKG_VERSION:=2.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=http://miniupnp.free.fr/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/miniupnpd/files/miniupnpd.hotplug
+++ b/miniupnpd/files/miniupnpd.hotplug
@@ -13,11 +13,9 @@
 
 [ ! "$ACTION" = "ifup" ] && service_check /usr/sbin/miniupnpd && exit 0
 
-local iface
-local ifname
-local tmpconf="/var/etc/miniupnpd.conf"
-local extiface=$(uci get upnpd.config.external_iface)
-local extzone=$(uci get upnpd.config.external_zone)
+tmpconf="/var/etc/miniupnpd.conf"
+extiface=$(uci get upnpd.config.external_iface)
+extzone=$(uci get upnpd.config.external_zone)
 
 . /lib/functions/network.sh
 

--- a/miniupnpd/files/miniupnpd.init
+++ b/miniupnpd/files/miniupnpd.init
@@ -1,7 +1,7 @@
 #!/bin/sh /etc/rc.common
 # Copyright (C) 2006-2014 OpenWrt.org
 
-START=95
+START=94
 STOP=15
 
 SERVICE_USE_PID=1


### PR DESCRIPTION
* Remove 'local' variable definitions from hotplug script's main body.   This fixes #231
  Busybox 1.25.0 does not allow local variables defined outside functions. LEDE is already using 1.25.0 and I noticed the problem, when miniupnpd started a regular logspam. (Apparently Busybox throws error and leaves the possible value assignment undone.)

* Change startup priority slightly from 95 to 94, so that miniupnpd starts before S95done (which is intended to be run last). With the current value 95, the /etc/rc.d symlink for miniupnpd is S95miniupnpd that gets run after S95done.

maintainer: @fingon 
