### PR TITLE
olsrd: disable compiler-warning "missing-include-dirs"

### DIFF
--- a/olsrd/patches/missing-include-dirs-warning.patch
+++ b/olsrd/patches/missing-include-dirs-warning.patch
@@ -1,0 +1,12 @@
+diff -ur olsrd-0.9.5_orig/lib/pud/nmealib/Makefile.inc olsrd-0.9.5/lib/pud/nmealib/Makefile.inc
+--- olsrd-0.9.5_orig/lib/pud/nmealib/Makefile.inc	2016-12-22 12:23:42.175283967 +0100
++++ olsrd-0.9.5/lib/pud/nmealib/Makefile.inc	2016-12-22 12:24:24.591015066 +0100
+@@ -63,7 +63,7 @@
+                 -Wmissing-format-attribute -Wno-multichar -Wno-deprecated-declarations -Wendif-labels -Wwrite-strings \
+                 -Wbad-function-cast -Wpointer-arith -Wcast-qual -Wshadow -Wformat -Wsequence-point -Wcast-align \
+                 -Wnested-externs -Winline -Wdisabled-optimization -funit-at-a-time -fPIC -ggdb -Wformat=2 -Winit-self \
+-                -Wmissing-include-dirs -Wswitch-default -Wswitch-enum -Wconversion -Wdouble-promotion \
++                -Wswitch-default -Wswitch-enum -Wconversion -Wdouble-promotion \
+                 -Werror=format-security -Wformat-security -Wformat-y2k -Wredundant-decls -Wundef -Wunreachable-code \
+                 -Wunused-parameter
+ 


### PR DESCRIPTION
remove this warning as it fails to build for the nmealib with missing
"staging_dir/target-mipsel_24kc_musl-1.1.15/include" from buildenv

this fixes #244 on OpenWrt + LEDE master (checked via SDK-build)