### PR TITLE
bmx7: Mark as broken since SSL library is EOL

### DIFF
--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -61,7 +61,7 @@ define Package/bmx7/Default
   TITLE:=BMX7 layer 3 routing daemon
   URL:=http://bmx6.net/
   MAINTAINER:=Axel Neumann <neumann@cgws.de>
-  DEPENDS:=+zlib +libpolarssl +libiwinfo
+  DEPENDS:=+zlib +libpolarssl +libiwinfo @BROKEN
 endef
 
 define Package/bmx7/description


### PR DESCRIPTION
PolarSSL/mbed TLS 1.3 is end of life, mark package as broken until support for mbed TLS 2.4 is added.

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>