### PR TITLE
miniupnpd: Update to 2.0.20161216

### DIFF
--- a/miniupnpd/Makefile
+++ b/miniupnpd/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=miniupnpd
-PKG_VERSION:=2.0
-PKG_RELEASE:=3
+PKG_VERSION:=2.0.20161216
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://miniupnp.free.fr/files
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=1c07a215dd9b362e75a9efc05e2fb3b4
+PKG_MD5SUM:=9e73d50ac830b5e08b6eb1df4e4c917833a5ab54351809f615d15d0f30cdeef3
 
 PKG_MAINTAINER:=Markus Stenberg <fingon@iki.fi>
 PKG_LICENSE:=BSD-3-Clause

--- a/miniupnpd/patches/105-enable_check_portinuse.patch
+++ b/miniupnpd/patches/105-enable_check_portinuse.patch
@@ -1,0 +1,11 @@
+--- a/genconfig.sh
++++ b/genconfig.sh
+@@ -467,7 +467,7 @@ echo "/* Uncomment the following line to
+ if [ -n "$PORTINUSE" ]; then
+ 	echo "#define CHECK_PORTINUSE" >> ${CONFIGFILE}
+ else
+-	echo "/*#define CHECK_PORTINUSE*/" >> ${CONFIGFILE}
++	echo "#define CHECK_PORTINUSE" >> ${CONFIGFILE}
+ fi
+ echo "" >> ${CONFIGFILE}
+ 

--- a/miniupnpd/patches/106-enable_igdv2.patch
+++ b/miniupnpd/patches/106-enable_igdv2.patch
@@ -1,0 +1,11 @@
+--- a/genconfig.sh
++++ b/genconfig.sh
+@@ -516,7 +516,7 @@ echo " * control points, so enable with
+ if [ -n "$IGD2" ]; then
+ 	echo "#define IGD_V2" >> ${CONFIGFILE}
+ else
+-	echo "/*#define IGD_V2*/" >> ${CONFIGFILE}
++	echo "#define IGD_V2" >> ${CONFIGFILE}
+ fi
+ echo "" >> ${CONFIGFILE}
+ 


### PR DESCRIPTION
Enable IGDv2 as v1 Device DCPs were deprecated as of March 30, 2015
Source: http://upnp.org/specs/gw/igd2

Enable port in use check

Patches are originally from the FreeBSD Ports repo and refreshed for this repo.
Source: https://svnweb.freebsd.org/ports/head/net/miniupnpd/files/

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>