### PR TITLE
babeld: Cleanup old compatibility code in initscript

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.8.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -11,10 +11,6 @@ OTHERCONFIGDIR="/tmp/babeld.d/"
 EXTRA_COMMANDS="status"
 EXTRA_HELP="        status Dump Babel's table to the log file."
 
-# Options to ignore for the global section (old options that are translated
-# for backward compatibility with old configuration files)
-ignored_options="carrier_sense assume_wireless no_split_horizon random_router_id multicast_address port hello_interval wired_hello_interval smoothing_half_time duplication_priority local_server conf_file conf_dir"
-
 # Append a line to the configuration file
 cfg_append() {
         local value="$1"
@@ -59,63 +55,6 @@ append_parm() {
 	config_get _loctmp "$section" "$option"
 	[ -z "$_loctmp" ] && return 0
 	append buffer "$switch $_loctmp"
-}
-
-
-# Provides backward compatibility for old option names in the global section.
-translate_option() {
-	local section="$1"
-	local old_option="$2"
-	local new_option="$3"
-	local _value
-	config_get _value "$section" "$old_option"
-	[ -z "$_value" ] && return
-	cfg_append "${new_option//_/-} $_value"
-}
-
-translate_bool() {
-	local section="$1"
-	local old_option="$2"
-	local new_option="$3"
-	local _bool
-	local _value
-	config_get_bool _bool "$section" "$old_option" 0
-	[ "$_bool" -eq 0 ] && return
-	cfg_append "${new_option//_/-} true"
-}
-
-# Adds a new interface section for setting default interface options.
-add_default_option() {
-	local option="$1"
-	local value="$2"
-	cfg_append "default ${option//_/-} $value"
-}
-
-# Global 'hello_interval' and 'wired_hello_interval' options are ignored,
-# because they have no direct equivalent: you should use
-# interface-specific settings.
-parse_old_global_options() {
-	local section="$1"
-	translate_bool   "$section" 'carrier_sense'	'link_detect'
-	translate_bool   "$section" 'random_router_id'	'random_id'
-	translate_option "$section" 'multicast_address'	'protocol_group'
-	translate_option "$section" 'port'		'protocol_port'
-	translate_option "$section" 'local_server'	'local_port'
-	translate_option "$section" 'smoothing_half_time'	'smoothing_half_life'
-	translate_option "$section" 'duplication_priority'	'allow_duplicates'
-	# These two global options are turned into default interface options.
-	local _bool
-	config_get_bool _bool "$section" 'assume_wireless' 0
-	[ "$_bool" -eq 1 ] && add_default_option "wired" "false"
-	config_get_bool _bool "$section" 'no_split_horizon' 0
-	[ "$_bool" -eq 1 ] && add_default_option "split_horizon" "false"
-        # Configure alternative configuration file and directory
-	local conf_file
-	config_get conf_file "$section" "conf_file"
-	[ -n "$conf_file" ] && OTHERCONFIGFILE="$conf_file"
-	local conf_dir
-	config_get conf_dir "$section" "conf_dir"
-	[ -n "$conf_dir" ] && OTHERCONFIGDIR="$conf_dir"
 }
 
 babel_filter() {
@@ -164,8 +103,9 @@ babel_config_cb() {
 		option_cb() {
 			local option="$1"
 			local value="$2"
-			# Ignore old options
-			list_contains ignored_options "$option" && return
+			# Ignore options that are not supposed to be given to babeld
+			[ "$option" = "conf_file" ] && return
+			[ "$option" = "conf_dir" ] && return
 			# Skip lists. They will be taken care of by list_cb
 			test "${option#*_ITEM}" != "$option" && return
 			test "${option#*_LENGTH}" != "$option" && return
@@ -175,9 +115,6 @@ babel_config_cb() {
 	"interface")
 		local _ifname
 		config_get _ifname "$section" 'ifname'
-		# Backward compatibility: try to use the section name
-		# if no "option ifname" was used.
-		[ -z "$_ifname" -a "${section:0:3}" != "cfg" ] && _ifname="$section"
 		# Try to resolve the logical interface name
 		unset interface
 		network_get_device interface "$_ifname" || interface="$_ifname"
@@ -212,27 +149,42 @@ babel_config_cb() {
 	esac
 }
 
+# Support for conf_file and conf_dir
+babel_configpaths() {
+	local cfg="$1"
+	local conf_file
+	config_get conf_file "$cfg" "conf_file"
+	[ -n "$conf_file" ] && OTHERCONFIGFILE="$conf_file"
+	local conf_dir
+	config_get conf_dir "$cfg" "conf_dir"
+	[ -n "$conf_dir" ] && OTHERCONFIGDIR="$conf_dir"
+}
+
 start_service() {
 	mkdir -p /var/lib
 	mkdir -p /var/etc
-	mkdir -p "$OTHERCONFIGDIR"
+
+	# First load the whole config file, without callbacks, so that we are
+	# aware of all "ignore" options in the second pass.  This also allows
+	# to load the configuration paths (conf_file and conf_dir).
+	config_load babeld
+
+	# Configure alternative configuration file and directory
+	config_foreach babel_configpaths "general"
 
 	# Start by emptying the generated config file
 	>"$CONFIGFILE"
 	# Import dynamic config files
+	mkdir -p "$OTHERCONFIGDIR"
 	for f in "$OTHERCONFIGDIR"/*.conf; do
 		[ -f "$f" ] && cat "$f" >> "$CONFIGFILE"
 	done
-	# First load the whole config file, without callbacks, so that we are
-	# aware of all "ignore" options in the second pass.
-	config_load babeld
+
 	# Parse general and interface sections thanks to the "config_cb()"
 	# callback.  This allows to loop over all options without having to
 	# know their name in advance.
 	config_cb() { babel_config_cb "$@"; }
 	config_load babeld
-	# Backward compatibility
-	config_foreach parse_old_global_options general
 	# Parse filters separately, since we know which options we expect
 	config_foreach babel_filter filter
 	procd_open_instance


### PR DESCRIPTION
It makes the init script more readable.  It has been more than two years
since babeld 1.5.1, let's hope nobody is still using the old
(undocumented) option names.

Incidentally, this commit fixes support for the "conf_dir" option,
introduced by ac643416dc ("babeld: allow changing alternative
configuration file and directory").  The default value of $OTHERCONFIGDIR
was always used, because the variable was used *before* it was (possibly)
redefined when parsing the UCI config.

Signed-off-by: Baptiste Jonglez <git@bitsofnetworks.org>