### PR TITLE
olsrd: nameservice: add postinst-hook to upgrade plugin

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -179,6 +179,54 @@ define Build/Compile
 	$(call Build/Compile/Default,libs)
 endef
 
+define Package/olsrd-mod-nameservice/postinst
+#!/bin/sh
+. "$${IPKG_INSTROOT}/lib/functions.sh"
+
+# gets lookup up on compiletime and path is stripped-off
+PLUGIN_CURRENT_VERSION=$(subst $(PKG_BUILD_DIR)/lib/nameservice/olsrd_nameservice.so.,,$(wildcard $(PKG_BUILD_DIR)/lib/nameservice/olsrd_nameservice.so.*))
+
+upgrade_plugin_options() {
+        local cfg=$$1
+        local version
+        local value
+
+        config_get value $$cfg library
+        if [ $${value:0:20} = olsrd_nameservice.so ]; then
+                #echo found nameservice
+                if [ $${value} = olsrd_nameservice.so.$${PLUGIN_CURRENT_VERSION} ]; then
+                        #echo section up-to-date
+                        return 0
+                fi
+                version=$${value/olsrd_nameservice.so./} # strip-off the library-name
+                major=$$(echo $$version | cut -d . -f 1)
+                minor=$$(echo $$version | cut -d . -f 2)
+                configured_ver=$$((major * 1000 + $$minor))
+                plugin_current_version_major=$$(echo $$PLUGIN_CURRENT_VERSION | cut -d . -f 1)
+                plugin_current_version_minor=$$(echo $$PLUGIN_CURRENT_VERSION | cut -d . -f 2)
+                current_ver=$$((plugin_current_version_major *1000 + $$plugin_current_version_minor))
+                if [ $${current_ver} -lt $${configured_ver} ]; then
+                        echo "downgrade of olsrd-mod-nameservice detected, please check your configuration"
+                        logger "downgrade of olsrd-mod-nameservice detected, please check your configuration"
+                        return 0
+                fi
+                echo "upgrading config ($$UCI_CONF_NAME) of nameservice-plugin to version $$PLUGIN_CURRENT_VERSION"
+                uci_set $$UCI_CONF_NAME "$$cfg" library "olsrd_nameservice.so.$${PLUGIN_CURRENT_VERSION}"
+                echo "... done"
+        fi
+}
+
+for uciconfig in olsrd olsrd6; do
+        . "$${IPKG_INSTROOT}/etc/init.d/$$uciconfig"  # get UCI_CONF_NAME variable
+
+        config_load $$UCI_CONF_NAME
+        config_foreach upgrade_plugin_options LoadPlugin
+        uci_commit $$UCI_CONF_NAME
+done
+
+exit 0
+endef
+
 define Package/olsrd/install
 	$(INSTALL_DIR) $(1)/lib/functions
 	$(INSTALL_DATA) ./files/olsrd.init $(1)/lib/functions/olsrd.sh


### PR DESCRIPTION
olsrd-0.9.6 will come with an new versionnumber for the nameservice-plugin, as of new parameter "filewrite_interval".
This commit installs a postinst-hook for mod-nameservice to update the UCI-option library to the new value. When installing the same version nothing is done, on downgrades a warning is printed.

Without this the parameter will stay at "olsrd-nameservice.so.0.3". The init-script will check for this filename and will not include this plugin into the runtime-config.