### PR TITLE
Add Prince to openwrt-routing

### DIFF
--- a/poprouting/Makefile
+++ b/poprouting/Makefile
@@ -28,8 +28,9 @@ define Package/prince/description
 Prince is an open source implementation of the PopRouting Algorithm.
 It has been developed as a Google Summer of Code Project in collaboration with Freifunk and the University of Trento.
 
-It fetches topology data from a Link State routing deamon(OONF, OLSR, OSPF, etc),
-uses the betweenness centrality to optimize the timer's value and pushes back the optimized timer.
+It work by fetching topology data from a Link State routing demon(OONF, OLSR, OSPF, etc),
+calculating the betweenness centrality using the topology, then using these data
+the timer's value are optimized. Finally the timers are pushed back to the routing demon.
 Currently it only supports OLSRd2 (aka OONF).
 endef
 

--- a/poprouting/Makefile
+++ b/poprouting/Makefile
@@ -1,0 +1,35 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=prince
+PKG_VERSION:=v0.2
+PKG_RELEASE:=2
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/prince-$(PKG_VERSION)
+PKG_USE_MIPS16:=0
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE:=prince-$(PKG_VERSION).tar.gz
+PKG_SOURCE_URL:=https://github.com/gabri94/poprouting.git
+PKG_SOURCE_VERSION:=v0.2
+PKG_SOURCE_SUBDIR:=prince-v0.2
+include $(INCLUDE_DIR)/package.mk
+define Package/prince
+	SECTION :=net
+	CATEGORY :=Network
+	SUBMENU :=Routing and Redirection
+	Mantainer :=Gabriele Gemmi <gabriel@autistici.org>
+	TITLE :=PopRouting daemon
+	MENU :=0
+	DEPENDS := +libjson-c +libpthread
+endef
+
+define Package/poprouting/description
+Prince is an open source implementation of the PopRouting Algorithm.
+It has been developed as a Google Summer of Code Project in collaboration with Freifunk and the University of Trento.
+
+It fetches topology data from a Link State routing deamon(OONF, OLSR, OSPF, etc),
+uses the betweenness centrality to optimize the timer's value and pushes back the optimized timer.
+Currently it only supports OLSRd2 (aka OONF).
+endef
+
+
+$(eval $(call BuildPackage,poprouting))

--- a/poprouting/Makefile
+++ b/poprouting/Makefile
@@ -12,17 +12,18 @@ PKG_SOURCE_URL:=https://github.com/gabri94/poprouting.git
 PKG_SOURCE_VERSION:=v0.2
 PKG_SOURCE_SUBDIR:=prince-v0.2
 include $(INCLUDE_DIR)/package.mk
+
 define Package/prince
 	SECTION :=net
 	CATEGORY :=Network
 	SUBMENU :=Routing and Redirection
 	Mantainer :=Gabriele Gemmi <gabriel@autistici.org>
 	TITLE :=PopRouting daemon
-	MENU :=0
+	MENU :=1
 	DEPENDS := +libjson-c +libpthread
 endef
 
-define Package/poprouting/description
+define Package/prince/description
 Prince is an open source implementation of the PopRouting Algorithm.
 It has been developed as a Google Summer of Code Project in collaboration with Freifunk and the University of Trento.
 

--- a/poprouting/Makefile
+++ b/poprouting/Makefile
@@ -20,7 +20,7 @@ define Package/prince
 	Mantainer :=Gabriele Gemmi <gabriel@autistici.org>
 	TITLE :=PopRouting daemon
 	URL :=https://github.com/gabri94/poprouting
-	MENU :=1
+	MENU :=0
 	DEPENDS := +libjson-c +libpthread
 endef
 
@@ -31,6 +31,14 @@ It has been developed as a Google Summer of Code Project in collaboration with F
 It fetches topology data from a Link State routing deamon(OONF, OLSR, OSPF, etc),
 uses the betweenness centrality to optimize the timer's value and pushes back the optimized timer.
 Currently it only supports OLSRd2 (aka OONF).
+endef
+
+define Package/prince/install
+	$(INSTALL_DIR) $(1)/usr/lib
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/graph-parser_c/build/lib/libgraphcparser.so $(1)/usr/lib/
+	$(INSTALL_DIR) $(1)/usr/sbin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/prince/build/prince_c $(1)/usr/sbin/
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/prince/build/libprince_oonf.so $(1)/usr/lib/
 endef
 
 

--- a/poprouting/Makefile
+++ b/poprouting/Makefile
@@ -19,6 +19,7 @@ define Package/prince
 	SUBMENU :=Routing and Redirection
 	Mantainer :=Gabriele Gemmi <gabriel@autistici.org>
 	TITLE :=PopRouting daemon
+	URL :=https://github.com/gabri94/poprouting
 	MENU :=1
 	DEPENDS := +libjson-c +libpthread
 endef
@@ -33,4 +34,4 @@ Currently it only supports OLSRd2 (aka OONF).
 endef
 
 
-$(eval $(call BuildPackage,poprouting))
+$(eval $(call BuildPackage,prince))


### PR DESCRIPTION
Hi, i would like to add my [implementation](https://github.com/gabri94/poprouting) for Pop-Routing to openwrt.
It is a demon used to optimize the timer's value of OONF, so i think it belongs to the routing feed.
I developed it as GSoC 2016 project with Freifunk and Ninux. 

Unfortunately due to a C++ Library the v0.1 version wasn't installable on embedded devices. (2MB of size)
Recently we've re-implemented this library in pure C and the new version (v0.2) has a tinier packet (20KB).

Thanks, Gabriel