### PR TITLE
batman-adv: use kernel-specific PKG_BUILD_DIR

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -11,17 +11,15 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=batman-adv
 
 PKG_VERSION:=2016.5
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 PKG_MD5SUM:=6717a933a08dd2a01b00df30cb9f16a8
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
 PKG_LICENSE:=GPL-2.0
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)
-
-include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/kernel.mk
+include $(INCLUDE_DIR)/package.mk
 
 define KernelPackage/batman-adv
   URL:=https://www.open-mesh.org/


### PR DESCRIPTION
@ecsv @lindnermarek

Please also apply to lede-17.01.

The batman-adv Makefile set a PKG_BUILD_DIR outside of KERNEL_BUILD_DIR;
this could lead to batman-adv not being rebuilt when switching targets and
thus kernel configurations. This resulted in ABI mismatches and
occasionally broke the build with messages like the following:

    Package kmod-batman-adv is missing dependencies for the following libraries:
    crc16.ko

Instead of setting a better PKG_BUILD_DIR ourselves, we can just remove
the explicit PKG_BUILD_DIR definition and include kernel.mk before
package.mk to get the default definition used by other kernel module
packages.

Reported-by: David Lutz <kpanic@hirnduenger.de>
Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>