### PR TITLE
batman-adv: compile batman v by default

### DIFF
--- a/batman-adv/Config.in
+++ b/batman-adv/Config.in
@@ -32,4 +32,4 @@ config KMOD_BATMAN_ADV_NC
 config KMOD_BATMAN_ADV_BATMAN_V
 	bool "enable batman v routing algorithm"
 	depends on PACKAGE_kmod-batman-adv
-	default n
+	default y


### PR DESCRIPTION
@simonwunderlich @ecsv

Compile BATMAN V per default to make the routing algorithm available in the snapshot builds and release packages.

Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>