### PR TITLE
miniupnpd: implement an 'enabled' flag

### DIFF
--- a/miniupnpd/files/miniupnpd.init
+++ b/miniupnpd/files/miniupnpd.init
@@ -68,7 +68,11 @@ start() {
 	local extip port usesysuptime conffile serial_number model_number
 	local uuid notify_interval presentation_url enable_upnp
 	local upnp_lease_file clean_ruleset_threshold clean_ruleset_interval
-        local ipv6_listening_ip
+        local ipv6_listening_ip enabled
+
+	config_get_bool enabled config enabled 1
+
+	[ "$enabled" -gt 0 ] || return 1
 
 	config_get extiface config external_iface
 	config_get extzone config external_zone

--- a/miniupnpd/files/upnpd.config
+++ b/miniupnpd/files/upnpd.config
@@ -1,4 +1,5 @@
 config upnpd config
+	option enabled		0
 	option enable_natpmp	1
 	option enable_upnp	1
 	option secure_mode	1


### PR DESCRIPTION
Add a 'master' miniupnpd service enable flag rather than just relying on
rcS.d script existence.  This allows the service to be disabled across
sysupgrade, similar to minidlna.

The service assumes enabled if no 'enabled' config flag is configured
for backwards compatibility.

Signed-off-by: Kevin Darbyshire-Bryant <kevin@darbyshire-bryant.me.uk>