### PR TITLE
mcproxy: remove pedantic flag to allow compilation with musl

### DIFF
--- a/mcproxy/patches/0001-add-cmake.patch
+++ b/mcproxy/patches/0001-add-cmake.patch
@@ -7,7 +7,7 @@
 +project(mcproxy CXX)
 +set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 +set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -std=c++11")
-+add_definitions(-Wall -Wextra -pedantic)
++add_definitions(-Wall -Wextra)
 +include_directories(${CMAKE_SOURCE_DIR}/mcproxy)
 +
 +


### PR DESCRIPTION
Signed-off-by: Stefan Peter <s.peter@mpl.ch>
--
Building mcproxy with musl fails:
[ 45%] Building CXX object CMakeFiles/mcproxy-bin.dir/mcproxy/src/proxy/proxy_instance.cpp.o
In file included from /opt/mpl/GUARD64/LEDE/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/lib/gcc/x86_64-openwrt-linux-musl/5.4.0/include/xmmintrin.h:34:0,
                 from /opt/mpl/GUARD64/LEDE/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/lib/gcc/x86_64-openwrt-linux-musl/5.4.0/include/x86intrin.h:31,
                 from /opt/mpl/GUARD64/LEDE/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/x86_64-openwrt-linux-musl/include/c++/5.4.0/x86_64-openwrt-linux-musl/bits/opt_random.h:33,
                 from /opt/mpl/GUARD64/LEDE/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/x86_64-openwrt-linux-musl/include/c++/5.4.0/random:50,
                 from /opt/mpl/GUARD64/LEDE/build_dir/target-x86_64_musl-1.1.16/mcproxy-2014-12-31-b7bd2d0809a0d1f177181c361b9a6c83e193b79a/mcproxy/src/proxy/proxy_instance.cpp:42:
/opt/mpl/GUARD64/LEDE/staging_dir/toolchain-x86_64_gcc-5.4.0_musl-1.1.16/lib/gcc/x86_64-openwrt-linux-musl/5.4.0/include/mm_malloc.h:34:64: error: declaration of 'int posix_memalign(void**, size_t, size_t) throw ()' has a different exception specifier
 extern "C" int posix_memalign (void **, size_t, size_t) throw ();
                                                                ^

Removing the -pedantic flag fixes this.
See https://gcc.gnu.org/ml/gcc-patches/2015-05/msg01425.html for further information.