### PR TITLE
olsrd: pud: does not depend on ncurses

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -119,7 +119,7 @@ endef
 
 define Package/olsrd-mod-pud
   $(call Package/olsrd/template)
-  DEPENDS:=olsrd +libgps +ncurses
+  DEPENDS:=olsrd +libgps
   TITLE:=Position Update Distribution plugin
 endef
 


### PR DESCRIPTION
BTW According to Matthias there is no ncurses package either way!

Signed-off-by: Ferry Huberts <ferry.huberts@pelagic.nl>