### PR TITLE
smcroute: make build id optional

### DIFF
--- a/smcroute/Makefile
+++ b/smcroute/Makefile
@@ -8,12 +8,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=smcroute
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_LICENSE:=GPL-2.0+
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz
 PKG_SOURCE_URL:=ftp://troglobit.com/smcroute/
 PKG_MD5SUM:=cbf478e52ab9ae411adca41b9d22f68a
+
+PKG_FIXUP:=autoreconf
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/smcroute/patches/001-Make-output-of-build-id-optional.patch
+++ b/smcroute/patches/001-Make-output-of-build-id-optional.patch
@@ -1,0 +1,65 @@
+Author: Micha Lenk <micha@lenk.info>
+Date: Thu, 7 May 2015 21:54:31 +0200
+Description: Make output of build id optional
+ With free software, anyone can inspect the source code for malicious flaws.
+ But the software is often provided as binary packages to its users. The idea
+ of “deterministic” or “reproducible” builds is to empower anyone to verify
+ that no flaws have been introduced during the build process by reproducing
+ byte-for-byte identical binary packages from a given source.  See also:
+ https://wiki.debian.org/ReproducibleBuilds
+ .
+ Prior to this change a timestamp generated at build time is included in the
+ output of 'smcroute -v'. As a result the binary is unreproducible.
+ .
+ With this change, users that still want 'smcroute -v' to include a build id
+ can run './configure --enable-build-id' to get the build id back (or even
+ specify a custom build id).
+Origin: upstream, https://github.com/troglobit/smcroute/commit/73f6f14907f709e40689216291621ad26cd22ecd
+Bug-Debian: https://bugs.debian.org/784694
+Last-Update: 2017-08-08
+
+---
+ configure.ac | 9 ++++++++-
+ smcroute.c   | 6 +++++-
+ 2 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 556d958..eb4a291 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -181,7 +181,14 @@ AC_COMPILE_IFELSE(
+   [AC_MSG_RESULT(no)])
+ 
+ # Add build number to config.h.in
+-AC_DEFINE_UNQUOTED([BUILD], "`date +%y%m%d`", [Build number, abbreviated date.])
++AC_ARG_ENABLE([build-id],
++  [AS_HELP_STRING([--enable-build-id@<:@=ID@:>@],
++              [show build id in output of 'smcroute -v'])],
++  [AS_IF([test "x$enableval" = "xyes" ],
++    [build_id=`date +%y%m%d`],
++    [build_id=$enableval])
++   AC_DEFINE_UNQUOTED([BUILD], "$build_id", [Build number, abbreviated date.])])
++
+ 
+ # Checks for library functions.
+ AC_FUNC_FORK
+diff --git a/smcroute.c b/smcroute.c
+index 7bd3c72..0287458 100644
+--- a/smcroute.c
++++ b/smcroute.c
+@@ -46,7 +46,11 @@ static const char *conf_file = SMCROUTE_SYSTEM_CONF;
+ 
+ extern char *__progname;
+ static const char version_info[] =
+-	"SMCRoute version " PACKAGE_VERSION " build " BUILD "\n";
++	"SMCRoute version " PACKAGE_VERSION
++#ifdef BUILD
++        " build " BUILD
++#endif
++        "\n";
+ 
+ static const char usage_info[] =
+ 	"Usage: smcroute [OPTIONS]... [ARGS]...\n"
+-- 
+2.11.0
+


### PR DESCRIPTION
The build id contains the build timestamp by default.
Make this field optional.
Build timestamp prevents reproducible builds [0].
Thanks to the debian project for the patch.

[0] https://reproducible-builds.org/docs/timestamps/

Signed-off-by: Alexander Couzens <lynxis@fe80.eu>