### PR TITLE
nodogsplash2: change configuration defaults

### DIFF
--- a/nodogsplash2/files/nodogsplash.config
+++ b/nodogsplash2/files/nodogsplash.config
@@ -14,7 +14,7 @@ config nodogsplash
 
   # The network the users are connected to
   option network 'lan'
-  option gatewayname 'OpenWrtLEDE Nodogsplash'
+  option gatewayname 'OpenWrt Nodogsplash'
   option maxclients '250'
   #Client timeouts in minutes
   option clientidletimeout '120'
@@ -61,7 +61,7 @@ config nodogsplash
   #MAC addresses that do not need to authenticate
   #list trustedmac '00:00:C0:01:D0:1D'
 
-  # Set FW_MARK for compatibilty with other OpenWrt/LEDE Packages eg mwan3, sqm etc.
+  # Set FW_MARK for compatibilty with other OpenWrt Packages eg mwan3, sqm etc.
   list fw_mark_authenticated '520'
   list fw_mark_trusted '510'
   list fw_mark_blocked '500'

--- a/nodogsplash2/files/nodogsplash.config
+++ b/nodogsplash2/files/nodogsplash.config
@@ -3,8 +3,8 @@
 # See https://github.com/nodogsplash/nodogsplash/blob/master/resources/nodogsplash.conf
 
 config nodogsplash
-  # Set to 1 to enable nodogsplash
-  option enabled 0
+  # Set to 0 to disable nodogsplash
+  option enabled 1
 
   # Serve the file splash.html from this directory
   option webroot '/etc/nodogsplash/htdocs'
@@ -14,27 +14,34 @@ config nodogsplash
 
   # The network the users are connected to
   option network 'lan'
-  option gatewayname 'LEDE Nodogsplash'
+  option gatewayname 'OpenWrtLEDE Nodogsplash'
   option maxclients '250'
-  option clientidletimeout '1200'
+  #Client timeouts in minutes
+  option clientidletimeout '120'
+  option clientforcetimeout '1440'
+
 
   # Your router may have several interfaces, and you
   # probably want to keep them private from the network/gatewayinterface.
   # If so, you should block the entire subnets on those interfaces, e.g.:
-  list authenticated_users 'block to 192.168.0.0/16'
-  list authenticated_users 'block to 10.0.0.0/8'
+  # list authenticated_users 'block to 192.168.0.0/16'
+  # list authenticated_users 'block to 10.0.0.0/8'
 
   # Typical ports you will probably want to open up.
-  list authenticated_users 'allow tcp port 22'
-  list authenticated_users 'allow tcp port 53'
-  list authenticated_users 'allow udp port 53'
-  list authenticated_users 'allow tcp port 80'
-  list authenticated_users 'allow tcp port 443'
+  #list authenticated_users 'allow tcp port 22'
+  #list authenticated_users 'allow tcp port 53'
+  #list authenticated_users 'allow udp port 53'
+  #list authenticated_users 'allow tcp port 80'
+  #list authenticated_users 'allow tcp port 443'
+  #Or for happy customers allow all
+  list authenticated_users 'allow all'
+
 
   # For preauthenticated users to resolve IP addresses in their
   # initial request not using the router itself as a DNS server,
-  list preauthenticated_users 'allow tcp port 53'
-  list preauthenticated_users 'allow udp port 53'
+  # Leave commented to help prevent DNS tunnelling
+  #list preauthenticated_users 'allow tcp port 53'
+  #list preauthenticated_users 'allow udp port 53'
 
   # Allow ports for SSH/Telnet/DNS/DHCP/HTTP/HTTPS
   list users_to_router 'allow tcp port 22'
@@ -43,7 +50,6 @@ config nodogsplash
   list users_to_router 'allow udp port 53'
   list users_to_router 'allow udp port 67'
   list users_to_router 'allow tcp port 80'
-  list users_to_router 'allow tcp port 443'
 
   # MAC addresses that are / are not allowed to access the splash page
   # Value is either 'allow' or 'block'. The allowedmac or blockedmac list is used.
@@ -54,3 +60,8 @@ config nodogsplash
 
   #MAC addresses that do not need to authenticate
   #list trustedmac '00:00:C0:01:D0:1D'
+
+  # Set FW_MARK for compatibilty with other OpenWrt/LEDE Packages eg mwan3, sqm etc.
+  list fw_mark_authenticated '520'
+  list fw_mark_trusted '510'
+  list fw_mark_blocked '500'


### PR DESCRIPTION
nodogsplash2: changes to defaults.
List of changes:
1. Set default to NoDogsplash enabled as rest of config should now be safe and is possible to SSH to router to stop NDS if needed
2. Change clientidletimeout to 120 minutes (2 hours)
3. Add clientforcetimeout set to 1440 minutes (24 hours)
4. Comment out the two provided example authenticated_users block lines
5. Add  list authenticated_users 'allow all'
6. Comment out original list authenticated_users 'allow... entries leaving as example.
7. Preauth default set to block remote DNS. All devices used at public wifi venues should be configured for DHCP. Forcing use of the local DNS server makes DNS tunnelling very inefficient if not unusable on a typical OpenWrt/LEDE device.
8. Add new fw_mark settings for compatibility with other OpenWrt packages.

Built and tested using LEDE 17.01.04
NDS installs without error and functions normally.  Device Captive Portal Detection (CPD)functions normally and splash.html is served. Tested with iOS/macOS, Android, Firefox, Linux NetworkManager, MSWindows7/8/10. On clicking the Continue button, Internet access is granted.
  
  