### PR TITLE
nodogsplash2: Fix Startup Failure

### DIFF
--- a/nodogsplash2/files/nodogsplash.config
+++ b/nodogsplash2/files/nodogsplash.config
@@ -12,14 +12,14 @@ config nodogsplash
   # Use plain configuration file
   #option config '/etc/nodogsplash/nodogsplash.conf'
 
-  # Set the network interface the users are connected to
+  # Use this option to set the network interface the users are connected to
   # Must not be used with option gatewayinterface
   # This option automatically identifies the active lan device for nodogsplash to bind to
   # This option may fail if the device configured for this interface is not up when nodogsplash starts at boot time
   # You may change this to any valid virtual lan interface that has been defined, eg lan, lan2, public_lan wlan2 etc
   # option network 'lan'
   
-  # Set the device nogogsplash will bind to
+  # Use this option to set the device nogogsplash will bind to
   # Must not be used with option network
   # The nodogsplash init script will wait for this device to be up before loading the nodogsplash service
   # You may change this to any valid lan device eg br-lan, wlan0, eth0.1 etc

--- a/nodogsplash2/files/nodogsplash.config
+++ b/nodogsplash2/files/nodogsplash.config
@@ -12,8 +12,19 @@ config nodogsplash
   # Use plain configuration file
   #option config '/etc/nodogsplash/nodogsplash.conf'
 
-  # The network the users are connected to
-  option network 'lan'
+  # Set the network interface the users are connected to
+  # Must not be used with option gatewayinterface
+  # This option automatically identifies the active lan device for nodogsplash to bind to
+  # This option may fail if the device configured for this interface is not up when nodogsplash starts at boot time
+  # You may change this to any valid virtual lan interface that has been defined, eg lan, lan2, public_lan wlan2 etc
+  # option network 'lan'
+  
+  # Set the device nogogsplash will bind to
+  # Must not be used with option network
+  # The nodogsplash init script will wait for this device to be up before loading the nodogsplash service
+  # You may change this to any valid lan device eg br-lan, wlan0, eth0.1 etc
+  option gatewayinterface 'br-lan'
+  
   option gatewayname 'OpenWrt Nodogsplash'
   option maxclients '250'
   #Client timeouts in minutes


### PR DESCRIPTION
This change will fix a problem where NoDogSplash2 Fails to start if the device it binds to is not ready.  