### PR TITLE
bird: remove incorrect build depends

### DIFF
--- a/bird/Makefile
+++ b/bird/Makefile
@@ -1,4 +1,4 @@
-# 
+#
 # Copyright (C) 2009-2016 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
@@ -13,7 +13,6 @@ PKG_RELEASE:=1
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
 PKG_MD5SUM:=39c51cf57c3ba8b5978b2a657ffa2f647ec7f3ae643e91cf42ee5cb070cf7e7c
-PKG_BUILD_DEPENDS:=libncurses libreadline
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
Build depends must refer to source rather than binary package names
(readline and ncurses instead of libreadline and libncurses).

As libreadline and libncurses are also runtime dependencies of the
individual binary packages, build depends on the corresponding source
packages are implied and the incorrect build depends can simply be removed.

See also: https://github.com/openwrt/packages/pull/5370