### PR TITLE
nat46: harden 464xlat teardown logic

### DIFF
--- a/nat46/Makefile
+++ b/nat46/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 include $(INCLUDE_DIR)/kernel.mk
 
 PKG_NAME:=nat46
-PKG_VERSION:=10
+PKG_VERSION:=11
 PKG_RELEASE:=$(PKG_SOURCE_VERSION)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.xz

--- a/nat46/files/464xlat.sh
+++ b/nat46/files/464xlat.sh
@@ -81,13 +81,14 @@ proto_464xlat_setup() {
 proto_464xlat_teardown() {
 	local cfg="$1"
 	local link="464-$cfg"
+
+	[ -f /tmp/464-$cfg-anycast ] || return
 	local ip6addr=$(cat /tmp/464-$cfg-anycast)
-	local anycast_active
 
 	464xlatcfg "$link"
 
 	rm -rf /tmp/464-$cfg-anycast
-	ip -6 rule del to $ip6addr lookup prelocal
+	[ -n "$ip6addr" ] && ip -6 rule del to $ip6addr lookup prelocal
 
 	if [ -z "$(ls /tmp/464-*-anycast 2>&-)" ]; then
 		ip -6 rule del from all lookup local


### PR DESCRIPTION
Quit the teardown function in case the file 464-$cfg-anycast is not
present as it means no clean up of ip rules is required.
It fixes error traces like "cat: can't open '/tmp/464-wan6_4-anycast':
No such file or directory" and "Error: inet6 prefix is expected rather
than "lookup"."
At the same time remove the unused variable anycast_active.

Signed-off-by: Hans Dedecker <dedeckeh@gmail.com>