### PR TITLE
bmx6/7: add pkg mirror hash

### DIFF
--- a/bmx6/Makefile
+++ b/bmx6/Makefile
@@ -32,6 +32,7 @@ PKG_SOURCE_URL:=git://github.com/bmx-routing/bmx6.git
 #PKG_SOURCE_URL:=file:///usr/src/bmx-routing/bmx6.git
 
 PKG_REV:=0312168aaa384379ccbefd4b2d936fc698664d5b
+PKG_MIRROR_HASH:=98acdbda8a8cadadf8141c7b8a17b6417112f70f3211b86abad23a8c7a28be10
 PKG_VERSION:=r2018020902
 PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0

--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -31,6 +31,7 @@ PKG_SOURCE_URL:=git://github.com/bmx-routing/bmx7.git
 #PKG_SOURCE_URL:=file:///usr/src/bmx-routing/bmx7.git
 
 PKG_REV:=58b3823262512a48f5174e6778b2368c55bd05d9
+PKG_MIRROR_HASH:=ea10f4c7caaef366cf654f315b12409c3da1f34fc3e09f5eb19ffbd60f54cb88
 PKG_VERSION:=r2018021802
 PKG_RELEASE:=5
 PKG_LICENSE:=GPL-2.0


### PR DESCRIPTION
@axn please add PKG_MIRROR_HASH when using larger git repos to reduce traffic and load on the buildbots.
