### PR TITLE
 nogogsplash2: Add compatibility with mwan3 v2

### DIFF
--- a/nodogsplash2/files/nodogsplash.config
+++ b/nodogsplash2/files/nodogsplash.config
@@ -73,6 +73,6 @@ config nodogsplash
   #list trustedmac '00:00:C0:01:D0:1D'
 
   # Set FW_MARK for compatibilty with other OpenWrt Packages eg mwan3, sqm etc.
-  list fw_mark_authenticated '520'
-  list fw_mark_trusted '510'
-  list fw_mark_blocked '500'
+  list fw_mark_authenticated '30000'
+  list fw_mark_trusted '20000'
+  list fw_mark_blocked '10000'


### PR DESCRIPTION
nogogsplash2: Add compatibility with mwan3 version 2
Changes in mwan3 version 2 resulted in previous recommended fix for Nodogsplash to fail.
Setting fw_mark to use bits set "higher" than used in mwan3 solves the problem. This works also for all previous versions of Nodogsplash.
Author-name: Rob White
Signed-off-by: Rob White <rob@blue-wave.net>