### PR TITLE
bmx7: convert init script to use procd

### DIFF
--- a/bmx7/files/etc/init.d/bmx7
+++ b/bmx7/files/etc/init.d/bmx7
@@ -1,41 +1,20 @@
 #!/bin/sh /etc/rc.common
-#    Copyright (C) 2011 Fundacio Privada per a la Xarxa Oberta, Lliure i Neutral guifi.net
-#
-#    This program is free software; you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation; either version 2 of the License, or
-#    (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
-#
-#    You should have received a copy of the GNU General Public License along
-#    with this program; if not, write to the Free Software Foundation, Inc.,
-#    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
-#    The full GNU General Public License is included in this distribution in
-#    the file called "COPYING".
-
 START=91
+USE_PROCD=1
 
 BIN=/usr/sbin/bmx7
 CONF=/etc/config/bmx7
-PID=/var/run/bmx7/pid
 
-
-start() {
+start_service() {
 	cd /root/
 	while pgrep -f mac80211.sh ; do sleep 1; done
-	ulimit -c 20000
-	$BIN -f $CONF -d0 > /dev/null &
-}
 
-stop() {
-	start-stop-daemon -p $PID -K
-}
-
-restart() {
-	stop; sleep 3; start
+	procd_open_instance "bmx7"
+	procd_set_param command "$BIN"
+	procd_append_param command -f "$CONF" -d0
+	procd_set_param limits core=20000
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_close_instance
 }


### PR DESCRIPTION
Using procd allows better control and monitoring of the bmx7 process.
Keep polling for mac80211.sh process for now until we find a better
way to make sure that wireless configuration has been generated before
starting bmx7.
Setting maximum core size to 20000 looks dangerous on small devices,
but keep it as it was before, we shall discuss this separately.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>