### PR TITLE
batman-adv 2018.1

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -8,10 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2018.0
+PKG_VERSION:=2018.1
 PKG_RELEASE:=0
-PKG_MD5SUM:=a0610a85cd55b9b1ff30b726dc5c455f
-PKG_HASH:=c7cfeb6defc46fe0da9d620afcf89ee36ddc034e31dee58cc239b757a77cf257
+PKG_HASH:=808fa6acf65c7a8e26405115176a5587157f746108cbe5dd974788eb05416d76
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -9,10 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
 
-PKG_VERSION:=2018.0
+PKG_VERSION:=2018.1
 PKG_RELEASE:=0
-PKG_MD5SUM:=cfdad757be0a2001158410366f6b9a45
-PKG_HASH:=5a970835b6c85e92a4faf2c40d70664cf80637749c30b898d0c84cfe94f1eff4
+PKG_HASH:=27877d0da6916f88a6cecbbb3f3d23cc4558ef7c7294324bf4fd050ed606b553
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -9,10 +9,9 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 
-PKG_VERSION:=2018.0
+PKG_VERSION:=2018.1
 PKG_RELEASE:=0
-PKG_MD5SUM:=c39d67cdb5509bf638efc9083e0dd41e
-PKG_HASH:=4826f838e8a2914a9470da25ea2f17f6325c464a130093b20dc7fb4e93f7576c
+PKG_HASH:=b866b28dbbe5c9238abbdf5abbc30fc526dea56898ce4c1bd76d5c017843048b
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)


### PR DESCRIPTION
@simonwunderlich 

batman-adv 2018.1
=================

* support latest kernels (3.2 - 4.17)
* coding style cleanups and refactoring
* add DAT cache and multicast flags netlink support
* avoid redundant multicast TT entries
* bugs squashed:
  - update data pointers after skb_cow()
  - fix header size check in batadv_dbg_arp()
  - fix skbuff rcsum on packet reroute
  - fix multicast-via-unicast transmission with AP isolation
  - fix packet loss for broadcasted DHCP packets to a server
  - fix multicast packet loss with a single WANT_ALL_IPV4/6 flag

batctl 2018.1
=============

* synchronization of batman-adv netlink and packet headers
* add DAT cache and multicast flags netlink support
* disable translation support for non-unicast mac addresses

alfred 2018.1
=============

* synchronization of batman-adv netlink header