### PR TITLE
nodogsplash2: Add NDS Restart Hook for Firewall

### DIFF
--- a/nodogsplash2/Makefile
+++ b/nodogsplash2/Makefile
@@ -54,6 +54,12 @@ define Package/nodogsplash2/install
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/nodogsplash/htdocs/images/
 endef
 
+define Package/nodogsplash2/postrm
+#!/bin/sh
+uci delete firewall.nodogsplash2
+uci commit firewall
+endef
+
 define Package/nodogsplash2/conffiles
 /etc/nodogsplash/nodogsplash.conf
 endef

--- a/nodogsplash2/files/nodogsplash.config
+++ b/nodogsplash2/files/nodogsplash.config
@@ -5,6 +5,10 @@
 config nodogsplash
   # Set to 0 to disable nodogsplash
   option enabled 1
+  
+  # Set to 0 to disable hook that makes Firewall restart nodogsplash when Firewall restarts
+  # This hook is needed as a restart of Firewall overwrites nodogsplash iptables entries
+  option fwhook_enabled '1'
 
   # Serve the file splash.html from this directory
   option webroot '/etc/nodogsplash/htdocs'

--- a/nodogsplash2/files/nodogsplash.init
+++ b/nodogsplash2/files/nodogsplash.init
@@ -267,9 +267,9 @@ start_service() {
   
   if [ $(uci get nodogsplash.@nodogsplash[0].fwhook_enabled) = "1" ] ; then
     if ! uci get firewall.nodogsplash2.path &> /dev/null ; then
-        if [ -f '/tmp/etc/ndshook.include' ] ; then
-          rm /tmp/etc/ndshook.include
-        fi
+      if [ -f '/tmp/etc/ndshook.include' ] ; then
+        rm /tmp/etc/ndshook.include
+      fi
       uci delete firewall.nodogsplash2 2> /dev/null
       uci set firewall.nodogsplash2=include
       uci set firewall.nodogsplash2.type=script

--- a/nodogsplash2/files/nodogsplash.init
+++ b/nodogsplash2/files/nodogsplash.init
@@ -252,10 +252,11 @@ depends() {
   if [ "$1" = "iptables" ] ; then
     if [ $(uci get nodogsplash.@nodogsplash[0].fwhook_enabled) = "1" ] ; then
       if $WD_DIR/ndsctl status > /dev/null; then
-      echo " * Restarting NodogSplash" 
-      /etc/init.d/nodogsplash restart
+       echo " * Restarting NodogSplash" 
+       /etc/init.d/nodogsplash restart
       fi
-    else   echo " * NodogSplash fwhook is disabled" 
+    else   echo " * NodogSplash fwhook is disabled"
+    
     fi
   fi
 }

--- a/nodogsplash2/files/nodogsplash.init
+++ b/nodogsplash2/files/nodogsplash.init
@@ -251,6 +251,26 @@ create_instance() {
 start_service() {
   include /lib/functions
 
+  if ! uci get firewall.nodogsplash2.path &> /dev/null ; then
+      if [ -f '/etc/nodogsplash/ndshook.sh' ] ; then
+        rm /etc/nodogsplash/ndshook.sh
+      fi
+    uci delete firewall.nodogsplash2 2> /dev/null
+    uci set firewall.nodogsplash2=include
+    uci set firewall.nodogsplash2.type=script
+    uci set firewall.nodogsplash2.path='/etc/nodogsplash/ndshook.sh'
+    uci commit firewall
+    /etc/init.d/firewall restart  2>&1 | logger
+  fi
+
+  if [ ! -f '/etc/nodogsplash/ndshook.sh' ] ; then
+    printf "#NDS Restart Hook Created by Nodogsplash. Do not modify.\n" > /etc/nodogsplash/ndshook.sh
+    printf "  if /usr/bin/ndsctl status > /dev/null; then\n" >> /etc/nodogsplash/ndshook.sh
+    printf "    echo \" * Restarting NodogSplash \"\n" >> /etc/nodogsplash/ndshook.sh
+    printf "    /etc/init.d/nodogsplash restart\n  fi\n" >> /etc/nodogsplash/ndshook.sh
+    chmod +x /etc/nodogsplash/ndshook.sh
+  fi
+
   mkdir -p /tmp/etc/
   config_load nodogsplash
 

--- a/nodogsplash2/files/nodogsplash.init
+++ b/nodogsplash2/files/nodogsplash.init
@@ -255,8 +255,8 @@ depends() {
        echo " * Restarting NodogSplash" 
        /etc/init.d/nodogsplash restart
       fi
-    else   echo " * NodogSplash fwhook is disabled"
-    
+    else
+      echo " * NodogSplash fwhook is disabled"
     fi
   fi
 }

--- a/nodogsplash2/files/nodogsplash.init
+++ b/nodogsplash2/files/nodogsplash.init
@@ -248,30 +248,41 @@ create_instance() {
   procd_close_instance
 }
 
+depends() {
+  if [ "$1" = "iptables" ] ; then
+    if [ $(uci get nodogsplash.@nodogsplash[0].fwhook_enabled) = "1" ] ; then
+      if $WD_DIR/ndsctl status > /dev/null; then
+      echo " * Restarting NodogSplash" 
+      /etc/init.d/nodogsplash restart
+      fi
+    else   echo " * NodogSplash fwhook is disabled" 
+    fi
+  fi
+}
+
 start_service() {
   include /lib/functions
-
-  if ! uci get firewall.nodogsplash2.path &> /dev/null ; then
-      if [ -f '/etc/nodogsplash/ndshook.sh' ] ; then
-        rm /etc/nodogsplash/ndshook.sh
-      fi
-    uci delete firewall.nodogsplash2 2> /dev/null
-    uci set firewall.nodogsplash2=include
-    uci set firewall.nodogsplash2.type=script
-    uci set firewall.nodogsplash2.path='/etc/nodogsplash/ndshook.sh'
-    uci commit firewall
-    /etc/init.d/firewall restart  2>&1 | logger
-  fi
-
-  if [ ! -f '/etc/nodogsplash/ndshook.sh' ] ; then
-    printf "#NDS Restart Hook Created by Nodogsplash. Do not modify.\n" > /etc/nodogsplash/ndshook.sh
-    printf "  if /usr/bin/ndsctl status > /dev/null; then\n" >> /etc/nodogsplash/ndshook.sh
-    printf "    echo \" * Restarting NodogSplash \"\n" >> /etc/nodogsplash/ndshook.sh
-    printf "    /etc/init.d/nodogsplash restart\n  fi\n" >> /etc/nodogsplash/ndshook.sh
-    chmod +x /etc/nodogsplash/ndshook.sh
-  fi
-
   mkdir -p /tmp/etc/
+  
+  if [ $(uci get nodogsplash.@nodogsplash[0].fwhook_enabled) = "1" ] ; then
+    if ! uci get firewall.nodogsplash2.path &> /dev/null ; then
+        if [ -f '/tmp/etc/ndshook.include' ] ; then
+          rm /tmp/etc/ndshook.include
+        fi
+      uci delete firewall.nodogsplash2 2> /dev/null
+      uci set firewall.nodogsplash2=include
+      uci set firewall.nodogsplash2.type=script
+      uci set firewall.nodogsplash2.path='/tmp/etc/ndshook.include'
+      uci commit firewall
+      /etc/init.d/firewall restart  2>&1 | logger
+    fi
+
+    if [ ! -f '/tmp/etc/ndshook.include' ] ; then
+      printf "if [ -f '/etc/init.d/nodogsplash' ] ; then /etc/init.d/nodogsplash depends iptables ; fi\n" > /tmp/etc/ndshook.include
+      chmod +x /tmp/etc/ndshook.include
+    fi
+  fi
+  
   config_load nodogsplash
 
   config_foreach create_instance nodogsplash


### PR DESCRIPTION
nodogsplash2: Add NDS Restart Hook for Firewall
NodogSplash iptables entries are overwritten if the OpenWrt Firewall is restarted.
This change adds an include hook to /etc/config/firewall to restart NodogSplash if Firewall is restarted.
Author-name: Rob White
Signed-off-by: Rob White rob@blue-wave.net