### PR TITLE
bird2: Disable libssh support

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -96,7 +96,7 @@ protocols, telling BIRD to show various information, telling it to show
 a routing table filtered by a filter, or asking BIRD to reconfigure.
 endef
 
-CONFIGURE_ARGS += --with-linux-headers="$(LINUX_DIR)"
+CONFIGURE_ARGS += --with-linux-headers="$(LINUX_DIR)"  --disable-libssh
 
 define Package/bird2/conffiles
 /etc/bird.conf


### PR DESCRIPTION
Explicitly disable libssh support
Fixes build failure on buildbots

" Package bird2 is missing dependencies for the following libraries:
libssh.so.4 "
http://downloads.lede-project.org/snapshots/faillogs/arm_cortex-a9_neon/routing/bird2/compile.txt

Signed-off-by: Daniel Engberg <daniel.engberg.lists@pyret.net>