### PR TITLE
pimbd: Fix gcc 7.3 compilation error

### DIFF
--- a/pimbd/Makefile
+++ b/pimbd/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=pimbd
-PKG_SOURCE_VERSION:=68f5fc803119e4b33a88b35c096f4d6ac28b6de5
-PKG_VERSION:=2015-08-18-$(PKG_SOURCE_VERSION)
+PKG_SOURCE_VERSION:=dbf4e5913b06e3160f506df15e6a047a403a5f21
+PKG_VERSION:=2018-06-19-$(PKG_SOURCE_VERSION)
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
@@ -17,7 +17,8 @@ include $(INCLUDE_DIR)/package.mk
 include $(INCLUDE_DIR)/cmake.mk
 
 # Spammy debug builds for now
-CMAKE_OPTIONS += -DL_LEVEL=7
+CMAKE_OPTIONS += -DL_LEVEL=7 \
+		 -DWITH_LIBUBOX=1
 
 define Package/pimbd
   SECTION:=net


### PR DESCRIPTION
Maintainer: @Oryon 
Compile tested: brcm47xx/ramips, mipsel, openwrt master

When compiling with gcc 7.3.0, we get this error:
```
pimbd-2015-08-18-68f5fc803119e4b33a88b35c096f4d6ac28b6de5/src/mrib.c:57:34:
error: braced-group within expression allowed only inside a function
 static uint32_t ipv4_rtr_alert = cpu_to_be32(0x94040000);
```
gcc 7.3.0 thinks that `cpu_to_be32()` is not a compile-time constant, so
it does not allow it to initialize `ipv4_rtr_alert` outside of a function.
We need to use `__constant_cpu_to_be32()` instead.

I've submitted this upstream as well: https://github.com/Oryon/pimbd/pull/3
(hopefully this won't count as a duplicate)

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>