### PR TITLE
ndppd: fix compile error with musl

### DIFF
--- a/ndppd/patches/0001-Version-bump.patch
+++ b/ndppd/patches/0001-Version-bump.patch
@@ -1,0 +1,22 @@
+From 715f9f330d8606d4a7b68900325f9b1455dd5368 Mon Sep 17 00:00:00 2001
+From: Rafael Cossovan <navossoc@gmail.com>
+Date: Tue, 3 Apr 2018 17:06:16 -0300
+Subject: [PATCH 1/3] Forgot to bump the version.
+
+---
+ src/ndppd.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/ndppd.h b/src/ndppd.h
+index 57ba829..3e11221 100644
+--- a/src/ndppd.h
++++ b/src/ndppd.h
+@@ -21,7 +21,7 @@
+ #define NDPPD_NS_BEGIN   namespace ndppd {
+ #define NDPPD_NS_END     }
+ 
+-#define NDPPD_VERSION   "0.2.4"
++#define NDPPD_VERSION   "0.2.5"
+ 
+ #include <assert.h>
+ 

--- a/ndppd/patches/0002-Fixes-strerror_r-GNU-XSI.patch
+++ b/ndppd/patches/0002-Fixes-strerror_r-GNU-XSI.patch
@@ -1,0 +1,55 @@
+From 1f610129b475b417509b251e022ad46d2210ff50 Mon Sep 17 00:00:00 2001
+From: Rafael Cossovan <navossoc@gmail.com>
+Date: Tue, 3 Apr 2018 17:04:35 -0300
+Subject: [PATCH 2/3] Fixes strerror_r GNU/XSI issue #40.
+ http://www.zverovich.net/2015/03/13/reliable-detection-of-strerror-variants.html
+
+---
+ src/logger.cc | 14 ++++++++++++-
+ src/logger.h  |  3 +++
+ 2 files changed, 15 insertions(+), 1 deletions(-)
+
+diff --git a/src/logger.cc b/src/logger.cc
+index 6ddbea9..6ccb2a0 100644
+--- a/src/logger.cc
++++ b/src/logger.cc
+@@ -84,6 +84,6 @@ std::string logger::err()
+ {
+     char buf[2048];
+-    return strerror_r(errno, buf, sizeof(buf));
++    return strerror_r_wrapper(strerror_r(errno, buf, sizeof(buf)), buf);
+ }
+ 
+ logger logger::error()
+@@ -221,4 +221,16 @@ 
+     return false;
+ }
+
++// XSI-compliant: int
++std::string logger::strerror_r_wrapper(int, char* s)
++{
++    return s;
++}
++
++// GNU-specific: char *
++std::string logger::strerror_r_wrapper(char* s, char*)
++{
++    return s;
++}
++
+ NDPPD_NS_END
+diff --git a/src/logger.h b/src/logger.h
+index 7d3d7db..0446595 100644
+--- a/src/logger.h
++++ b/src/logger.h
+@@ -91,6 +91,9 @@ class logger {
+ 
+     static int _max_pri;
+ 
++    // helpers for strerror_r
++    static std::string strerror_r_wrapper(int, char* s);
++    static std::string strerror_r_wrapper(char* s, char*);
+ 
+ };
+ 
+

--- a/ndppd/patches/0003-fix-poll-header.patch
+++ b/ndppd/patches/0003-fix-poll-header.patch
@@ -1,0 +1,64 @@
+From 88b9bc561ce42f2eb97ea041cd8920797b44dd53 Mon Sep 17 00:00:00 2001
+From: Rafael Cossovan <navossoc@gmail.com>
+Date: Tue, 3 Apr 2018 17:05:42 -0300
+Subject: [PATCH 3/3] Fixes a compile warning when building with musl: #warning
+ redirecting incorrect #include <sys/poll.h> to <poll.h>
+
+---
+ src/iface.cc | 2 +-
+ src/iface.h  | 2 +-
+ src/proxy.h  | 2 +-
+ src/rule.h   | 2 +-
+ 4 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/iface.cc b/src/iface.cc
+index f569d3c..7cbb57f 100644
+--- a/src/iface.cc
++++ b/src/iface.cc
+@@ -30,7 +30,7 @@
+ #include <sys/ioctl.h>
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ #include <linux/filter.h>
+ 
+diff --git a/src/iface.h b/src/iface.h
+index 9db59ab..df7ff35 100644
+--- a/src/iface.h
++++ b/src/iface.h
+@@ -20,7 +20,7 @@
+ #include <vector>
+ #include <map>
+ 
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <net/ethernet.h>
+ 
+ #include "ndppd.h"
+diff --git a/src/proxy.h b/src/proxy.h
+index 8141b2a..9299d9a 100644
+--- a/src/proxy.h
++++ b/src/proxy.h
+@@ -19,7 +19,7 @@
+ #include <vector>
+ #include <map>
+ 
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ #include "ndppd.h"
+ 
+diff --git a/src/rule.h b/src/rule.h
+index 0c2f79a..23086e6 100644
+--- a/src/rule.h
++++ b/src/rule.h
+@@ -20,6 +20,6 @@
+ #include <map>
+ 
+-#include <sys/poll.h>
++#include <poll.h>
+ 
+ #include "ndppd.h"
+


### PR DESCRIPTION
Error:
src/logger.cc: In static member function 'static std::string ndppd::logger::err()':
src/logger.cc:86:22: error: could not convert 'strerror_r((*__errno_location()), ((char*)(& buf)), sizeof (buf))'
                            from 'int' to 'std::string {aka std::basic_string<char>}'
    return strerror_r(errno, buf, sizeof(buf));

Added and modified some patches from
https://github.com/DanielAdolfsson/ndppd/compare/eb81b8f2d6d4d33545570402b049a73880b9ad01...navossoc:master
(See https://github.com/DanielAdolfsson/ndppd/issues/40 for details)

Maintainer: @kerneis 

Compile-tested: octeon + mpc85xx openwrt master, musl + uclibc++
                octeon openwrt master, glibc + libstdc++

Run-tested: octeon openwrt master, musl + uclibc++

Signed-off-by: Martin Strobel <arctus@crza.de>