### PR TITLE
nodogsplash: fix minor things

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -29,6 +29,7 @@ define Package/nodogsplash
 	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
 	TITLE:=Open public network gateway daemon
 	URL:=https://github.com/nodogsplash/nodogsplash
+	CONFLICTS:=nodogsplash2
 endef
 
 define Package/nodogsplash/description

--- a/nodogsplash/files/etc/uci-defaults/40_nodogsplash
+++ b/nodogsplash/files/etc/uci-defaults/40_nodogsplash
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-uci batch <<-EOT
+uci -q batch <<-EOF
 	delete firewall.nodogsplash
 	set firewall.nodogsplash=include
 	set firewall.nodogsplash.type=script


### PR DESCRIPTION
Fixes a heredoc block and add nodogsplash2 as a conflicting package.