### PR TITLE
backport: luci-app-cjdns: luci admin support for cjdns-v20.2 (#394)

### DIFF
--- a/luci-app-cjdns/Makefile
+++ b/luci-app-cjdns/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2014,2015 Hyperboria.net
+# Copyright (C) 2014,2018 Hyperboria.net
 #
 # You may redistribute this program and/or modify it under the terms of
 # the GNU General Public License as published by the Free Software Foundation,
@@ -18,7 +18,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-cjdns
 PKG_VERSION:=1.3
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_LICENSE:=GPL-3.0
 
@@ -29,7 +29,7 @@ define Package/luci-app-cjdns
 	CATEGORY:=LuCI
 	SUBMENU:=3. Applications
 	TITLE:=Encrypted near-zero-conf mesh routing protocol
-	URL:=https://github.com/hyperboria/cjdns
+	URL:=https://github.com/cjdelisle/cjdns
 	MAINTAINER:=Lars Gierth <larsg@systemli.org>
 	DEPENDS:=+cjdns +luci-base
 endef

--- a/luci-app-cjdns/luasrc/view/cjdns/status.htm
+++ b/luci-app-cjdns/luasrc/view/cjdns/status.htm
@@ -1,116 +1,67 @@
 <script type="text/javascript">//<![CDATA[
-
-	var peersURI = '<%=luci.dispatcher.build_url("admin", "services", "cjdns", "peers")%>';
-	var updatePeers = function(x, peers) {
-		var table = document.getElementById('cjdns-peerings');
-		while (table.rows.length > 1) {
-			table.deleteRow(1);
+	/* 75lb/usage-stats */
+	function lbbytes (bytes){
+		var kilobyte = 1024,
+			megabyte = kilobyte * 1024,
+			gigabyte = megabyte * 1024,
+			terabyte = gigabyte * 1024;
+		if ((bytes >= 0) && (bytes < kilobyte)) {
+			return bytes + " B";
+		} else if ((bytes >= kilobyte) && (bytes < megabyte)) {
+			return (bytes / kilobyte).toFixed(2) + " KB";
+		} else if ((bytes >= megabyte) && (bytes < gigabyte)) {
+			return (bytes / megabyte).toFixed(2) + " MB";
+		} else if ((bytes >= gigabyte) && (bytes < terabyte)) {
+			return (bytes / gigabyte).toFixed(2) + " GB";
+		} else if (bytes >= terabyte) {
+			return (bytes / terabyte).toFixed(2) + " TB";
+		} else {
+			return bytes + " B";
 		}
+	}
 
-		if ((peers) && ((peers.err) || (typeof peers.length === 'undefined'))) {
-			var errpeer = (peers.err)
-						? 'Socket Error: unable to connect to Admin API'
-						: 'No active peers';
-			var row = table.insertRow(-1);
-			row.className = 'cbi-section-table-row';
-			var cell = row.insertCell(-1);
-			cell.colSpan = 7;
-			cell.textContent = errpeer;
-			return;
-		};
+	XHR.poll(5, '<%=luci.dispatcher.build_url("admin", "services", "cjdns", "peers")%>', null,
+		function(x, st) {
+			var table = document.getElementById('cjdns-peerings');
+			if (st && table) {
+				var rows = [];
+				st.forEach(function(peer) {
+					rows.push([
+						peer.lladdr,
+						peer.ipv6,
+						peer.version,
+						((peer.isIncoming === 0) ? 'outgoing, ' : 'incoming, ').concat(peer.state.toLowerCase()),
+						lbbytes(peer.bytesIn) + ' / ' + lbbytes(peer.bytesOut),
+						(peer.user == null) ? '-' : peer.user
+					]);
+				});
 
-		peers.forEach(function(peer, i) {
-			if (peer.user == null) {
-				var user = '';
-			} else if (peer.user == 'Local Peers') {
-				var user = 'beacon';
-			} else {
-				var user = peer.user;
+				if (typeof(cbi_update_table) == 'function') {
+					cbi_update_table(table, rows, '<em><%:Querying Admin API%></em>');
+				} else {
+					while (table.rows.length > 1) { table.deleteRow(1); }
+					rows.forEach(function(peer) {
+						var row = table.insertRow(-1);
+						peer.forEach(function(x) { row.insertCell(-1).textContent = x; });
+					});
+				}
 			}
-
-			if (peer.isIncoming === 0) {
-				var interface = 'outgoing';
-			} else {
-				var interface = 'incoming';
-			}
-
-			var status = interface + ', ' + peer.state.toLowerCase();
-
-			if (peer.version === 0) {
-				var version = '-';
-			} else {
-				var version = 'v' + peer.version;
-			}
-
-			var rxtx = lbbytes(peer.bytesIn) + ' / ' + lbbytes(peer.bytesOut);
-
-			var row = table.insertRow(-1);
-			row.className = 'cbi-section-table-row cbi-rowstyle-' + ((i % 2) + 1);
-			row.insertCell(-1).textContent = user;
-			row.insertCell(-1).textContent = peer.ipv6;
-			row.insertCell(-1).textContent = status;
-			row.insertCell(-1).textContent = version;
-			row.insertCell(-1).textContent = rxtx;
-			var latencyCell = row.insertCell(-1);
-			latencyCell.textContent = 'waiting';
-
-			var pingURI = '<%=luci.dispatcher.build_url("admin", "services", "cjdns", "ping")%>';
-			var timeout = 2000;
-			XHR.get(pingURI, { label: peer.switchLabel, timeout: timeout }, function(x, pong) {
-				var pongrsp = ((pong.err == "ai:recv > timeout") || (pong == "undefined") || (pong.ms >= timeout))
-					? '> ' + timeout + ' ms'
-					: pong.ms + ' ms';
-				latencyCell.textContent = pongrsp;
-			})
-		});
-
-	};
-
-	XHR.get(peersURI, null, updatePeers);
-	XHR.poll(5, peersURI, null, updatePeers);
-
+		}
+	);
 //]]></script>
 
-<script type="text/javascript">
-<%# Author: [GitHub/75lb] -%>
-//<![CDATA[
-function lbbytes (bytes){
-
-	var kilobyte = 1024,
-	    megabyte = kilobyte * 1024,
-	    gigabyte = megabyte * 1024,
-	    terabyte = gigabyte * 1024;
-
-	if ((bytes >= 0) && (bytes < kilobyte)) {
-		return bytes + " B";
-	} else if ((bytes >= kilobyte) && (bytes < megabyte)) {
-		return (bytes / kilobyte).toFixed(2) + " KB";
-	} else if ((bytes >= megabyte) && (bytes < gigabyte)) {
-		return (bytes / megabyte).toFixed(2) + " MB";
-	} else if ((bytes >= gigabyte) && (bytes < terabyte)) {
-		return (bytes / gigabyte).toFixed(2) + " GB";
-	} else if (bytes >= terabyte) {
-		return (bytes / terabyte).toFixed(2) + " TB";
-	} else {
-		return bytes + " B";
-	}
-};
-//]]>
-</script>
-
-<fieldset class="cbi-section">
-	<legend>Active cjdns peers</legend>
-	<table class="cbi-section-table" id="cjdns-peerings">
-		<tr class="cbi-section-table-titles">
-			<th class="cbi-section-table-cell">User/Name</th>
-			<th class="cbi-section-table-cell">IPv6</th>
-			<th class="cbi-section-table-cell">Status</th>
-			<th class="cbi-section-table-cell">Version</th>
-			<th class="cbi-section-table-cell">Rx / Tx</th>
-			<th class="cbi-section-table-cell">Latency</th>
-		</tr>
-		<tr class="cbi-section-table-row">
-			<td colspan="7">Querying Admin API</td>
-		</tr>
-	</table>
-</fieldset>
+<div class="cbi-map">
+	<fieldset class="cbi-section">
+		<legend><%:Active cjdns peers%></legend>
+		<table class="table" id="cjdns-peerings">
+			<tr class="tr table-titles">
+				<th class="th nowrap">Address</th>
+				<th class="th nowrap">IPv6</th>
+				<th class="th nowrap">Version</th>
+				<th class="th nowrap">Status</th>
+				<th class="th nowrap">Rx / Tx</th>
+				<th class="th nowrap">User/Name</th>
+			</tr>
+		</table>
+	</fieldset>
+</div>


### PR DESCRIPTION
This fixes empty HTML table, XHR handling and minor CSS changes for 18.06.