### PR TITLE
nodogsplash: add missing config options

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
 PKG_VERSION:=3.2.0
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz

--- a/nodogsplash/files/etc/config/nodogsplash
+++ b/nodogsplash/files/etc/config/nodogsplash
@@ -27,8 +27,13 @@ config nodogsplash
   #option debuglevel '7'
 
   # Client timeouts in minutes
-  option preauthidletimeout '10'
+  option preauthidletimeout '30'
   option authidletimeout '120'
+  # Session Timeout is the interval after which clients are forced out (a value of 0 means never)
+  option sessiontimeout '1200'
+
+  # The interval in seconds at which nodogsplash checks client timeout status
+  option checkinterval '600'
 
   # Enable BinAuth Support.
   # If set, a program is called with several parameters on authentication (request) and deauthentication.

--- a/nodogsplash/files/etc/init.d/nodogsplash
+++ b/nodogsplash/files/etc/init.d/nodogsplash
@@ -139,9 +139,10 @@ generate_uci_config() {
   for option in binauth fasport fasremoteip faspath fas_secure_enabled \
     daemon debuglevel maxclients gatewayname gatewayinterface gatewayiprange \
     gatewayaddress gatewayport webroot splashpage statuspage imagesdir pagesdir \
-    redirecturl preauthidletimeout authidletimeout checkinterval setmss mssvalue \
-    trafficcontrol downloadlimit uploadlimit downloadimq uploadimq syslogfacility \
-    ndsctlsocket fw_mark_authenticated fw_mark_blocked fw_mark_trusted
+    redirecturl sessiontimeout preauthidletimeout authidletimeout checkinterval \
+    setmss mssvalue trafficcontrol downloadlimit uploadlimit \
+    syslogfacility ndsctlsocket fw_mark_authenticated \
+    fw_mark_blocked fw_mark_trusted
   do
     config_get val "$cfg" "$option"
 


### PR DESCRIPTION
sessiontimeout (minutes) until client is forced out
checkinterval (seconds) interval at which nodogsplash checks client timeout status

Add real world useful values to timeout options.

Signed-off-by: Rob White rob@blue-wave.net