### PR TITLE
nodogsplash: Backport v3.2.1 to OpenWrt 18.06

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=c9712c21c2cc88724a8104fa63edd4f69d31af24db0fad84db6105fae2d65809
+PKG_HASH:=fdc936b1b76bcae9a0a42cd8887d4cb5037fb328449a57c2c33f03ad5013638c
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -49,6 +49,7 @@ define Package/nodogsplash/install
 
 	$(INSTALL_DIR) $(1)/etc/nodogsplash/htdocs/images
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.html $(1)/etc/nodogsplash/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.css $(1)/etc/nodogsplash/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/status.html $(1)/etc/nodogsplash/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/nodogsplash/htdocs/images/
 endef


### PR DESCRIPTION
This release provides bugfixes and some minor enhancements:

  * reset upload/download counter when a client has been authenticated a second time [mwarning]
  * print sesssion duration as 0 in "ndsctl json" and "ndsctl clients" output when a session has not been started [mwarning]
  * rework html templater to speed up splash page generation [mwarning]
  * FAS documentation updates [bluewavenet]
  * Add CSS file and update splash and status html [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>