### PR TITLE
babeld: Update to 1.8.3

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
-PKG_VERSION:=1.8.2
+PKG_VERSION:=1.8.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
-PKG_HASH:=07edecb132386d5561a767482bc5200e04239b18e48c2f0f47ae1c78d60fe5dc
+PKG_HASH:=368cc56812e07bbb64d0b609b6f411292e46b15610fe947501d4b310377366bd
 PKG_LICENSE:=MIT
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
Update to recently released version 1.8.3.
This contains some nice fixes for kernels 4.16 and up which will become interesting as OpenWrt moves to 4.19
Full changelog:
  * Fixed a read-only two byte buffer overflow in the packet parser.
    This is a read-only overflow, and hence most probably not exploitable.
  * Fixed an issue with creating unreachable routes on recent kernels
    (4.16 and up).  Thanks to Christof Schulze.
  * Notice interface changes faster by listening to more netlink events.
    Thanks to Christof Schulze.
  * Fixed a local interface issue when an interface has no link-local
address. Thanks to Christof Schulze.

Signed-off-by: Robert Marko <robimarko@gmail.com>