### PR TITLE
nodogsplash: fix download link

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -12,7 +12,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=fdc936b1b76bcae9a0a42cd8887d4cb5037fb328449a57c2c33f03ad5013638c
+PKG_HASH:=16da76ecf7820cd8b32081237e05b24a7d2d8a9db8a47242badc7937d6cf1ae8
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
The tagging of the release was wrong, as a result, the hash is different from the usual package tar.gz.
The content has been verified to be the same.

Signed-off-by: Moritz Warning <moritzwarning@web.de>