### PR TITLE
batman-adv package fixes

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
 PKG_VERSION:=2018.3
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 PKG_HASH:=6265b8a3e99186ecb6e0cf7dde84fe8b67c66d9fefa6286f9f12110e98f28b1a
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -59,7 +59,8 @@ MAKE_ALFRED_FLAGS=\
 	CONFIG_ALFRED_GPSD=$(if $(CONFIG_PACKAGE_ALFRED_GPSD),y,n) \
 	CONFIG_ALFRED_CAPABILITIES=n \
         LIBNL_NAME="libnl-tiny" \
-        LIBNL_GENL_NAME="libnl-tiny"
+        LIBNL_GENL_NAME="libnl-tiny" \
+        REVISION="openwrt-$(PKG_VERSION)-$(PKG_RELEASE)"
 
 TARGET_CFLAGS  += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -fuse-linker-plugin

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=batctl
 
 PKG_VERSION:=2018.3
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 PKG_HASH:=24e32d3fe8268ce0951903546e71b925b78b17acc8809ba899940f48a5e892e6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -62,7 +62,8 @@ MAKE_BATCTL_ARGS += \
         REVISION="$(PKG_BATCTL_SHORTREV)" \
         CC="$(TARGET_CC)" \
         DESTDIR="$(PKG_INSTALL_DIR)" \
-        batctl install
+        batctl install \
+        REVISION="openwrt-$(PKG_VERSION)-$(PKG_RELEASE)"
 
 
 define Build/Compile

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -17,8 +17,6 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
 PKG_LICENSE:=GPL-2.0
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)/$(PKG_NAME)-$(PKG_VERSION)
-
 include $(INCLUDE_DIR)/package.mk
 
 define Package/batctl

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -16,6 +16,7 @@ PKG_HASH:=33f3f942203732e0568a6bc0226a0fe8eb147c961f0d0c13b2e6b16237d412ff
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
 PKG_LICENSE:=GPL-2.0
+PKG_EXTMOD_SUBDIRS=net/batman-adv
 
 STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
 

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -17,6 +17,8 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
 PKG_LICENSE:=GPL-2.0
 
+STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+
 include $(INCLUDE_DIR)/kernel.mk
 include $(INCLUDE_DIR)/package.mk
 

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=batman-adv
 
 PKG_VERSION:=2018.3
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 PKG_HASH:=33f3f942203732e0568a6bc0226a0fe8eb147c961f0d0c13b2e6b16237d412ff
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
@@ -69,7 +69,8 @@ NOSTDINC_FLAGS = \
 	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
 	-I$(PKG_BUILD_DIR)/include/ \
 	-include backport/backport.h \
-	-include $(PKG_BUILD_DIR)/compat-hacks.h
+	-include $(PKG_BUILD_DIR)/compat-hacks.h \
+	-DBATADV_SOURCE_VERSION=\\\"openwrt-$(PKG_VERSION)-$(PKG_RELEASE)\\\"
 
 COMPAT_SOURCES = \
 	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \


### PR DESCRIPTION
@simonwunderlich  These are various fixes for the batman-adv related packages. But there are two main changes:

The Module.symvers with the exported symbols of all other kernel modules in OpenWrt is usually placed in the main source directory of the package. But the actual sources for batman-adv are found in net/batman-adv. OpenWrt must therefore be informed to move it to this subdirectory or otherwise modpost will fail to find the symbols

    WARNING: "cfg80211_get_station" [.../batman-adv-2018.3/net/batman-adv/batman-adv.ko] undefined!

The dependency will then be missing in the .modinfo depends= option and thus it the kernel module loader will not correctly load the cfg80211.ko during bootup.

----

Add openwrt revision to internal version
    
OpenWrt is using a modified version of the software and these modifications may introduce extra bugs (or behavior changes). It is also patched for stable releases instead of switching to new releases. The revision should therefore be added to the version number to make it easier understandable which modified version the user may have installed.