### PR TITLE
batman-adv: Cleanup of configuration options

### DIFF
--- a/batman-adv/Config.in
+++ b/batman-adv/Config.in
@@ -2,6 +2,7 @@
 config KMOD_BATMAN_ADV_DEBUG_LOG
 	bool "enable verbose debug logging"
 	depends on PACKAGE_kmod-batman-adv
+	depends on KMOD_BATMAN_ADV_DEBUGFS
 	default n
 
 config KMOD_BATMAN_ADV_BLA

--- a/batman-adv/Config.in
+++ b/batman-adv/Config.in
@@ -1,35 +1,97 @@
+# SPDX-License-Identifier: GPL-2.0
+# Copyright (C) 2007-2018  B.A.T.M.A.N. contributors:
+#
+# Marek Lindner, Simon Wunderlich
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of version 2 of the GNU General Public
+# License as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+#
+# B.A.T.M.A.N meshing protocol
+#
 
 config KMOD_BATMAN_ADV_BATMAN_V
-	bool "enable batman v routing algorithm"
+	bool "B.A.T.M.A.N. V protocol"
 	depends on PACKAGE_kmod-batman-adv
 	default y
+	help
+	  This option enables the B.A.T.M.A.N. V protocol, the successor
+	  of the currently used B.A.T.M.A.N. IV protocol. The main
+	  changes include splitting of the OGM protocol into a neighbor
+	  discovery protocol (Echo Location Protocol, ELP) and a new OGM
+	  Protocol OGMv2 for flooding protocol information through the
+	  network, as well as a throughput based metric.
+	  B.A.T.M.A.N. V is currently considered experimental and not
+	  compatible to B.A.T.M.A.N. IV networks.
 
 config KMOD_BATMAN_ADV_BLA
-	bool "enable bridge loop avoidance"
+	bool "Bridge Loop Avoidance"
 	depends on PACKAGE_kmod-batman-adv
+	select PACKAGE_kmod-lib-crc16
 	default y
+	help
+	  This option enables BLA (Bridge Loop Avoidance), a mechanism
+	  to avoid Ethernet frames looping when mesh nodes are connected
+	  to both the same LAN and the same mesh. If you will never use
+	  more than one mesh node in the same LAN, you can safely remove
+	  this feature and save some space.
 
 config KMOD_BATMAN_ADV_DAT
-	bool "enable distributed arp table"
+	bool "Distributed ARP Table"
 	depends on PACKAGE_kmod-batman-adv
 	default y
+	help
+	  This option enables DAT (Distributed ARP Table), a DHT based
+	  mechanism that increases ARP reliability on sparse wireless
+	  mesh networks. If you think that your network does not need
+	  this option you can safely remove it and save some space.
 
 config KMOD_BATMAN_ADV_NC
-	bool "enable network coding [requires promisc mode support]"
+	bool "Network Coding"
 	depends on PACKAGE_kmod-batman-adv
-	default n
+	help
+	  This option enables network coding, a mechanism that aims to
+	  increase the overall network throughput by fusing multiple
+	  packets in one transmission.
+	  Note that interfaces controlled by batman-adv must be manually
+	  configured to have promiscuous mode enabled in order to make
+	  network coding work.
+	  If you think that your network does not need this feature you
+	  can safely disable it and save some space.
 
 config KMOD_BATMAN_ADV_MCAST
-	bool "enable multicast transmission optimization"
+	bool "Multicast optimisation"
 	depends on PACKAGE_kmod-batman-adv
+	help
+	  This option enables the multicast optimisation which aims to
+	  reduce the air overhead while improving the reliability of
+	  multicast messages.
 
 config KMOD_BATMAN_ADV_DEBUGFS
-	bool "enable debugfs support"
+	bool "batman-adv debugfs entries"
 	depends on PACKAGE_kmod-batman-adv
-	default n
+	select KERNEL_DEBUG_FS
+	help
+	  Enable this to export routing related debug tables via debugfs.
+	  The information for each soft-interface and used hard-interface can be
+	  found under batman_adv/
+
+	  If unsure, say N.
 
 config KMOD_BATMAN_ADV_DEBUG_LOG
-	bool "enable verbose debug logging"
-	depends on PACKAGE_kmod-batman-adv
+	bool "B.A.T.M.A.N. debugging"
 	depends on KMOD_BATMAN_ADV_DEBUGFS
-	default n
+	help
+	  This is an option for use by developers; most people should
+	  say N here. This enables compilation of support for
+	  outputting debugging information to the kernel log. The
+	  output is controlled via the module parameter debug.

--- a/batman-adv/Config.in
+++ b/batman-adv/Config.in
@@ -1,9 +1,8 @@
 
-config KMOD_BATMAN_ADV_DEBUG_LOG
-	bool "enable verbose debug logging"
+config KMOD_BATMAN_ADV_BATMAN_V
+	bool "enable batman v routing algorithm"
 	depends on PACKAGE_kmod-batman-adv
-	depends on KMOD_BATMAN_ADV_DEBUGFS
-	default n
+	default y
 
 config KMOD_BATMAN_ADV_BLA
 	bool "enable bridge loop avoidance"
@@ -15,8 +14,8 @@ config KMOD_BATMAN_ADV_DAT
 	depends on PACKAGE_kmod-batman-adv
 	default y
 
-config KMOD_BATMAN_ADV_DEBUGFS
-	bool "enable debugfs support"
+config KMOD_BATMAN_ADV_NC
+	bool "enable network coding [requires promisc mode support]"
 	depends on PACKAGE_kmod-batman-adv
 	default n
 
@@ -25,12 +24,13 @@ config KMOD_BATMAN_ADV_MCAST
 	depends on PACKAGE_kmod-batman-adv
 	default y
 
-config KMOD_BATMAN_ADV_NC
-	bool "enable network coding [requires promisc mode support]"
+config KMOD_BATMAN_ADV_DEBUGFS
+	bool "enable debugfs support"
 	depends on PACKAGE_kmod-batman-adv
 	default n
 
-config KMOD_BATMAN_ADV_BATMAN_V
-	bool "enable batman v routing algorithm"
+config KMOD_BATMAN_ADV_DEBUG_LOG
+	bool "enable verbose debug logging"
 	depends on PACKAGE_kmod-batman-adv
-	default y
+	depends on KMOD_BATMAN_ADV_DEBUGFS
+	default n

--- a/batman-adv/Config.in
+++ b/batman-adv/Config.in
@@ -19,7 +19,7 @@
 # B.A.T.M.A.N meshing protocol
 #
 
-config KMOD_BATMAN_ADV_BATMAN_V
+config BATMAN_ADV_BATMAN_V
 	bool "B.A.T.M.A.N. V protocol"
 	depends on PACKAGE_kmod-batman-adv
 	default y
@@ -33,7 +33,7 @@ config KMOD_BATMAN_ADV_BATMAN_V
 	  B.A.T.M.A.N. V is currently considered experimental and not
 	  compatible to B.A.T.M.A.N. IV networks.
 
-config KMOD_BATMAN_ADV_BLA
+config BATMAN_ADV_BLA
 	bool "Bridge Loop Avoidance"
 	depends on PACKAGE_kmod-batman-adv
 	select PACKAGE_kmod-lib-crc16
@@ -45,7 +45,7 @@ config KMOD_BATMAN_ADV_BLA
 	  more than one mesh node in the same LAN, you can safely remove
 	  this feature and save some space.
 
-config KMOD_BATMAN_ADV_DAT
+config BATMAN_ADV_DAT
 	bool "Distributed ARP Table"
 	depends on PACKAGE_kmod-batman-adv
 	default y
@@ -55,7 +55,7 @@ config KMOD_BATMAN_ADV_DAT
 	  mesh networks. If you think that your network does not need
 	  this option you can safely remove it and save some space.
 
-config KMOD_BATMAN_ADV_NC
+config BATMAN_ADV_NC
 	bool "Network Coding"
 	depends on PACKAGE_kmod-batman-adv
 	help
@@ -68,7 +68,7 @@ config KMOD_BATMAN_ADV_NC
 	  If you think that your network does not need this feature you
 	  can safely disable it and save some space.
 
-config KMOD_BATMAN_ADV_MCAST
+config BATMAN_ADV_MCAST
 	bool "Multicast optimisation"
 	depends on PACKAGE_kmod-batman-adv
 	help
@@ -76,7 +76,7 @@ config KMOD_BATMAN_ADV_MCAST
 	  reduce the air overhead while improving the reliability of
 	  multicast messages.
 
-config KMOD_BATMAN_ADV_DEBUGFS
+config BATMAN_ADV_DEBUGFS
 	bool "batman-adv debugfs entries"
 	depends on PACKAGE_kmod-batman-adv
 	select KERNEL_DEBUG_FS
@@ -87,9 +87,9 @@ config KMOD_BATMAN_ADV_DEBUGFS
 
 	  If unsure, say N.
 
-config KMOD_BATMAN_ADV_DEBUG_LOG
+config BATMAN_ADV_DEBUG
 	bool "B.A.T.M.A.N. debugging"
-	depends on KMOD_BATMAN_ADV_DEBUGFS
+	depends on BATMAN_ADV_DEBUGFS
 	help
 	  This is an option for use by developers; most people should
 	  say N here. This enables compilation of support for

--- a/batman-adv/Config.in
+++ b/batman-adv/Config.in
@@ -22,7 +22,6 @@ config KMOD_BATMAN_ADV_NC
 config KMOD_BATMAN_ADV_MCAST
 	bool "enable multicast transmission optimization"
 	depends on PACKAGE_kmod-batman-adv
-	default y
 
 config KMOD_BATMAN_ADV_DEBUGFS
 	bool "enable debugfs support"

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -27,16 +27,19 @@ define KernelPackage/batman-adv
   URL:=https://www.open-mesh.org/
   MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
   SUBMENU:=Network Support
-  DEPENDS:=+KMOD_BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-crypto-crc32c +kmod-lib-crc32c +kmod-cfg80211
+  DEPENDS:=+kmod-crypto-crc32c +kmod-lib-crc32c +kmod-cfg80211
   TITLE:=B.A.T.M.A.N. Adv
   FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoProbe,batman-adv)
 endef
 
 define KernelPackage/batman-adv/description
-B.A.T.M.A.N. advanced is a kernel module which allows to
-build layer 2 mesh networks. This package builds
-version $(PKG_VERSION) of the kernel module.
+B.A.T.M.A.N. (better approach to mobile ad-hoc networking) is
+a routing protocol for multi-hop ad-hoc mesh networks. The
+networks may be wired or wireless. See
+https://www.open-mesh.org/ for more information and user space
+tools. This package builds version $(PKG_VERSION) of the kernel
+module.
 endef
 
 define KernelPackage/batman-adv/config

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -52,13 +52,13 @@ endef
 
 PKG_EXTRA_KCONFIG:= \
 	CONFIG_BATMAN_ADV=m \
-	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_KMOD_BATMAN_ADV_DEBUG_LOG),y,n) \
-	CONFIG_BATMAN_ADV_DEBUGFS=$(if $(CONFIG_KMOD_BATMAN_ADV_DEBUGFS),y,n) \
-	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_KMOD_BATMAN_ADV_BLA),y,n) \
-	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_KMOD_BATMAN_ADV_DAT),y,n) \
-	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),y,n) \
-	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_KMOD_BATMAN_ADV_NC),y,n) \
-	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_KMOD_BATMAN_ADV_BATMAN_V),y,n) \
+	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_BATMAN_ADV_DEBUG),y,n) \
+	CONFIG_BATMAN_ADV_DEBUGFS=$(if $(CONFIG_BATMAN_ADV_DEBUGFS),y,n) \
+	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_BATMAN_ADV_BLA),y,n) \
+	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_BATMAN_ADV_DAT),y,n) \
+	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_BATMAN_ADV_MCAST),y,n) \
+	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_BATMAN_ADV_NC),y,n) \
+	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_BATMAN_ADV_BATMAN_V),y,n) \
 
 PKG_EXTRA_CFLAGS:= \
 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=m,%,$(filter %=m,$(PKG_EXTRA_KCONFIG)))) \
@@ -76,9 +76,9 @@ NOSTDINC_FLAGS = \
 	-DBATADV_SOURCE_VERSION=\\\"openwrt-$(PKG_VERSION)-$(PKG_RELEASE)\\\"
 
 COMPAT_SOURCES = \
-	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
-	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
-	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
+	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
+	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
+	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
 
 define Build/Compile
 	+env "batman-adv-y=$(COMPAT_SOURCES)" \

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -27,7 +27,7 @@ define KernelPackage/batman-adv
   URL:=https://www.open-mesh.org/
   MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
   SUBMENU:=Network Support
-  DEPENDS:=+kmod-crypto-crc32c +kmod-lib-crc32c +kmod-cfg80211
+  DEPENDS:=+kmod-lib-crc32c +kmod-cfg80211
   TITLE:=B.A.T.M.A.N. Adv
   FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
   AUTOLOAD:=$(call AutoProbe,batman-adv)


### PR DESCRIPTION
@simonwunderlich 

The kernel already provides all available kernel options for batman-adv and even includes more verbose descriptions of each option. Importing this Kconfig (with minor adjustments) file as Config.in allows to share most information between kernel and OpenWrt.