### PR TITLE
luci-app-bmx6: Fix URL of network topology JSON file

### DIFF
--- a/luci-app-bmx6/bmx6/www/luci-static/resources/bmx6/js/bmx6-graph.js
+++ b/luci-app-bmx6/bmx6/www/luci-static/resources/bmx6/js/bmx6-graph.js
@@ -48,7 +48,7 @@ function init() {
 
   divwait = document.getElementById("wait");
 
-  XHR.get('/cgi-bin/luci/status/bmx6/topology', null, function(nodesRequest, nodesData) {
+  XHR.get('/cgi-bin/luci/admin/network/BMX6/topology', null, function(nodesRequest, nodesData) {
     nodes = nodesData;
 
     XHR.get('/cgi-bin/bmx6-info?$myself&', null, function(myselfRequest, myselfData) {


### PR DESCRIPTION
The JavaScript code of the network graph tried to fetch the topology from
%HOST/cgi-bin/luci/status/bmx6/topology, but the topology entry is now located
at admin->network->BMX6 (i.e., %HOST/cgi-bin/luci/admin/network/BMX6/topology).

Fixes #432

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>