### PR TITLE
luci-app-bmx6: Fix corner case in bmx6-info?tunnels

### DIFF
--- a/luci-app-bmx6/bmx6/www/cgi-bin/bmx6-info
+++ b/luci-app-bmx6/bmx6/www/cgi-bin/bmx6-info
@@ -43,7 +43,7 @@ print_query() {
         i=$(( $i + 1 ))
       done
       echo -n " ] }"
-      
+
       # If /all has been specified, printing all the files together
       } || {
       comma=""
@@ -77,7 +77,7 @@ if [ "$QUERY" == 'myself' ]; then
   echo -n "{\"myself\":{\"hostname\":\"$hostname\",\"ip6\":\"$ip6\",\"ip4\":\"$ip4\",\"net6\":\"$cidr6\",\"net4\":\"$cidr4\"}}"
   exit 0
 fi
-    
+
 if [ "$QUERY" == 'info' ]; then
   echo -n '{ "info": [ '
   print_query status
@@ -100,7 +100,12 @@ if [ "$QUERY" == 'neighbours' ]; then
 fi
 
 if [ "$QUERY" == 'tunnels' ]; then
-  bmx6 -c --jshow tunnels /r=0
+  tunnels=$(bmx6 -c --jshow tunnels /r=0)
+  if [ -z $tunnels ]; then
+    echo '{ "tunnels" : [] }'
+  else
+    echo $tunnels
+  fi
   exit 0
 fi
 


### PR DESCRIPTION
The bmx6-info script will return null when no tunnels are known to BMX6.
However, the "Graph" and the "Tunnels" pages expect a JSON structure with an
array of tunnels. In case no tunnels are known to BMX6, bmx6-info now returns
'{ "tunnels" : [] }'.

Fixes #434

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>