### PR TITLE
luci-app-bmx6: Avoid race condition in bmx6json.lua get()

### DIFF
--- a/luci-app-bmx6/bmx6/usr/lib/lua/luci/model/bmx6json.lua
+++ b/luci-app-bmx6/bmx6/usr/lib/lua/luci/model/bmx6json.lua
@@ -59,6 +59,7 @@ function get(field, host)
 
 	if json_url[1] == "http"  then
 		raw,err = wget(url..field,1000)
+		sys.exec("")
 	else
 
 		if json_url[1] == "exec" then


### PR DESCRIPTION
This commit adds a dirty fix to issue https://github.com/openwrt-routing/packages/issues/436. Just adding the sys.exec("") call makes the topology and the graph be shown properly, not even a sleep command is needed.

Ideally, the wget() function should be reviewed by any of the contributors (@nicopace, @p4u) to properly identify where the problem is and fix it.

Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>