### PR TITLE
nodogsplash: fix invalid pointer bug when clock is turned back

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
 PKG_VERSION:=3.2.1
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz

--- a/nodogsplash/patches/0001-fix-invalid-pointer-when-clock-is-turned-back.patch
+++ b/nodogsplash/patches/0001-fix-invalid-pointer-when-clock-is-turned-back.patch
@@ -1,0 +1,51 @@
+From af548c1f885e46309baa6aa175a3822fd16afb2a Mon Sep 17 00:00:00 2001
+From: Moritz Warning <moritzwarning@web.de>
+Date: Thu, 14 Mar 2019 17:19:40 +0100
+Subject: [PATCH] fix invalid pointer when clock is turned back
+
+---
+ src/util.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/util.c b/src/util.c
+index 621062d..77228bf 100644
+--- a/src/util.c
++++ b/src/util.c
+@@ -362,14 +362,14 @@ format_duration(time_t from, time_t to, char buf[64])
+ {
+ 	int days, hours, minutes, seconds;
+ 	long long int secs;
++	const char *neg = "";
+ 
+ 	if (from <= to) {
+ 		secs = to - from;
+ 	} else {
+ 		secs = from - to;
+ 		// Prepend minus sign
+-		buf[0] = '-';
+-		buf += 1;
++		neg = "-";
+ 	}
+ 
+ 	days = secs / (24 * 60 * 60);
+@@ -381,13 +381,13 @@ format_duration(time_t from, time_t to, char buf[64])
+ 	seconds = secs;
+ 
+ 	if (days > 0) {
+-		sprintf(buf, "%dd %dh %dm %ds", days, hours, minutes, seconds);
++		snprintf(buf, 64, "%s%dd %dh %dm %ds", neg, days, hours, minutes, seconds);
+ 	} else if (hours > 0) {
+-		sprintf(buf, "%dh %dm %ds", hours, minutes, seconds);
++		snprintf(buf, 64, "%s%dh %dm %ds", neg, hours, minutes, seconds);
+ 	} else if (minutes > 0) {
+-		sprintf(buf, "%dm %ds", minutes, seconds);
++		snprintf(buf, 64, "%s%dm %ds", neg, minutes, seconds);
+ 	} else {
+-		sprintf(buf, "%ds", seconds);
++		snprintf(buf, 64, "%s%ds", neg, seconds);
+ 	}
+ 
+ 	return buf;
+-- 
+2.20.1
+


### PR DESCRIPTION
Fixes a invalid pointer error when the clock is set into the past while nodogsplash is running.

Tested with current OpenWrt master and Nexx wt3020.