### PR TITLE
batman-adv: Fix uci commit target

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=batman-adv
 
 PKG_VERSION:=2019.0
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 PKG_HASH:=3e97d8a771cdbd7b2df42c52b88e071eaa58b5d28eb4e17a4b13b6698debbdc0
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz

--- a/batman-adv/files/etc/uci-defaults/99-migrate-batadv_hardif
+++ b/batman-adv/files/etc/uci-defaults/99-migrate-batadv_hardif
@@ -89,7 +89,7 @@ if [ -f /etc/config/batman-adv ]; then
 
     config_load batman-adv
     config_foreach mv_batadv_config_section 'mesh'
-    uci commit batman-adv
+    uci commit network
 
     rm -f /etc/config/batman-adv
 fi


### PR DESCRIPTION
Although batman-adv config is cycled in config_foreach, changes
are made in the network config. Thus, this one has to be committed.

Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>