### PR TITLE
nodogsplash: update libmicrohttpd dependency

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
 PKG_VERSION:=3.3.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/nodogsplash
 	SUBMENU:=Captive Portals
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd
+	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
 	TITLE:=Open public network gateway daemon
 	URL:=https://github.com/nodogsplash/nodogsplash
 	CONFLICTS:=nodogsplash2


### PR DESCRIPTION
Maintainer: Moritz Warning <moritzwarning@web.de>

Description: Pending merge of PR openwrt/packages #8563, revert name of no-ssl version to libmicrohttpd-no-ssl
Currently, libmicrohtppd-ssl with its dependencies gets installed along with nodogsplash using a large amount of flash storage. 

Signed-off-by: Rob White <rob@blue-wave.net>