### PR TITLE
nodogsplash: Release v3.3.1-1

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=3.3.0
-PKG_RELEASE:=1
+PKG_VERSION:=3.3.1
+PKG_RELEASE:=1-19.0x
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=ad89af14086982ebb07da6dd079c10e93e31af149e06611649d0dbee79cb8e67
+PKG_HASH:=7480e720136b5945d71ce730e873385ee8ca13dabfc9fb4657a27ec3ae5e7841
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -59,6 +59,7 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/init.d/nodogsplash $(1)/etc/init.d/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/nodogsplash/login.sh
 endef
 
 define Package/nodogsplash/postrm

--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
 PKG_VERSION:=3.3.1
-PKG_RELEASE:=1-19.0x
+PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
@@ -26,7 +26,7 @@ define Package/nodogsplash
 	SUBMENU:=Captive Portals
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd
+	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
 	TITLE:=Open public network gateway daemon
 	URL:=https://github.com/nodogsplash/nodogsplash
 	CONFLICTS:=nodogsplash2


### PR DESCRIPTION
nodogsplash: Release v3.3.1-1

`Maintainer: Moritz Warning <moritzwarning@web.de>`

Compiled and tested on snapshot SDK mips_24kc and arm_cortex-a5_neon-vfpv4/

**Known Issue** - on OpenWrt >18.x.x, a problem with libmicrohttpd results in
the gnutls suite being installed causing potential out of memory errors on
devices <= 64M RAM.

**This version will fail to install on Openwrt 18.06 and 17.01** and is therefore flagged as package release 1-19.0x to facilitate backporting to 18.06 by flagging as 1-18.06 there with the appropriate libmicrohttpd dependency.

`Signed-off-by: Rob White <rob@blue-wave.net>`