### PR TITLE
nodogsplash: Release v3.3.2-1

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=3.3.0
+PKG_VERSION:=3.3.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=ad89af14086982ebb07da6dd079c10e93e31af149e06611649d0dbee79cb8e67
+PKG_HASH:=5a7b14dd2cce6a8ca261a720d87948565fc2f05d4926bf155b9e0db483ff6bcb
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -26,7 +26,7 @@ define Package/nodogsplash
 	SUBMENU:=Captive Portals
 	SECTION:=net
 	CATEGORY:=Network
-	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd
+	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
 	TITLE:=Open public network gateway daemon
 	URL:=https://github.com/nodogsplash/nodogsplash
 	CONFLICTS:=nodogsplash2
@@ -59,6 +59,7 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/init.d/nodogsplash $(1)/etc/init.d/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/nodogsplash/login.sh
 endef
 
 define Package/nodogsplash/postrm


### PR DESCRIPTION
Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested on snapshot SDK mips_24kc and arm_cortex-a5_neon-vfpv4/

  * Fix Issue introduced in v3.3.0 with the addition of Improvements towards usable IPv6 support, that caused CPD on client devices to fail with "Too Many Redirects" error. NDS now terminates gracefully with a console error if fasremoteip is not set AND fasport=80  [bluewavenet]
  * Validate fasremoteip to ensure that if it is set, then it is a valid dotted format IPv4 address  [bluewavenet]
  * Numerous Documentation updates  [bluewavenet]
  * Fix to Known Issue on OpenWrt >18.x.x with v3.3.1. This was caused by misconfigured Makefile for libmicrohttpd; this has been fixed there [bluewavenet]

Signed-off-by: Rob White `<rob@blue-wave.net>`