### PR TITLE
Fix babeld interface configuration in init script

### DIFF
--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -177,6 +177,10 @@ babel_configpaths() {
 start_service() {
 	mkdir -p /var/lib
 	mkdir -p /var/etc
+	mkdir -p "$OTHERCONFIGDIR"
+
+	# Start by emptying the generated config file
+	>"$CONFIGFILE"
 
 	# First load the whole config file, without callbacks, so that we are
 	# aware of all "ignore" options in the second pass.  This also allows
@@ -186,14 +190,6 @@ start_service() {
 	# Configure alternative configuration file and directory
 	config_foreach babel_configpaths "general"
 
-	# Start by emptying the generated config file
-	>"$CONFIGFILE"
-	# Import dynamic config files
-	mkdir -p "$OTHERCONFIGDIR"
-	for f in "$OTHERCONFIGDIR"/*.conf; do
-		[ -f "$f" ] && cat "$f" >> "$CONFIGFILE"
-	done
-
 	# Parse general and interface sections thanks to the "config_cb()"
 	# callback.  This allows to loop over all options without having to
 	# know their name in advance.
@@ -201,13 +197,24 @@ start_service() {
 	config_load babeld
 	# Parse filters separately, since we know which options we expect
 	config_foreach babel_filter filter
+
+	# Import dynamic config files
+	for f in "$OTHERCONFIGDIR"/*.conf; do
+		[ -f "$f" ] && cat "$f" >> "$CONFIGFILE"
+	done
+
 	procd_open_instance
 	# Using multiple config files is supported since babeld 1.5.1
 	procd_set_param command /usr/sbin/babeld -I "" -c "$OTHERCONFIGFILE" -c "$CONFIGFILE"
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param file "$OTHERCONFIGFILE" "$OTHERCONFIGDIR"/*.conf "$CONFIGFILE"
-	procd_set_param respawn
+
+	### Respawn automatically when process dies, after waiting respawn_timeout seconds
+	### If respawn_retry consecutives respawns die before respawn_threshold seconds (i.e. they crash)
+	### it will stop trying and leave it dead.
+	procd_set_param respawn ${respawn_threshold:-60} ${respawn_timeout:-3} ${respawn_retry:-5}
+
 	procd_close_instance
 }
 

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -9,8 +9,6 @@ CONFIGFILE='/var/etc/babeld.conf'
 OTHERCONFIGFILE="/etc/babeld.conf"
 OTHERCONFIGDIR="/tmp/babeld.d/"
 TMPCONFIGDIR="/tmp/babeld_init_d/"
-EXTRA_COMMANDS="status"
-EXTRA_HELP="        status Dump Babel's table to the log file."
 
 # Append a line to the configuration file
 cfg_append() {
@@ -229,8 +227,4 @@ start_service() {
 
 service_triggers() {
 	procd_add_reload_trigger babeld
-}
-
-status() {
-	kill -USR1 $(pgrep -P 1 babeld)
 }

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -133,7 +133,12 @@ babel_config_cb() {
 		}
 
 		interfaceFile="${OTHERCONFIGDIR}/interface_$interface.conf"
-		echo "interface $interface" > "$interfaceFile"
+
+		if [ "$interface" == "default" ]; then
+			echo "default" > "$interfaceFile"
+		else
+			echo "interface $interface" > "$interfaceFile"
+		fi
 
 		option_cb()
 		{

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -8,6 +8,7 @@ START=70
 CONFIGFILE='/var/etc/babeld.conf'
 OTHERCONFIGFILE="/etc/babeld.conf"
 OTHERCONFIGDIR="/tmp/babeld.d/"
+TMPCONFIGDIR="/tmp/babeld_init_d/"
 EXTRA_COMMANDS="status"
 EXTRA_HELP="        status Dump Babel's table to the log file."
 
@@ -136,7 +137,7 @@ babel_config_cb() {
 			return
 		}
 
-		interfaceFile="${OTHERCONFIGDIR}/interface_$interface.conf"
+		interfaceFile="${TMPCONFIGDIR}/interface_$interface.conf"
 
 		if [ "$interface" == "default" ]; then
 			echo "default" > "$interfaceFile"
@@ -178,6 +179,8 @@ start_service() {
 	mkdir -p /var/lib
 	mkdir -p /var/etc
 	mkdir -p "$OTHERCONFIGDIR"
+	rm -rf "$TMPCONFIGDIR"
+	mkdir -p "$TMPCONFIGDIR"
 
 	# Start by emptying the generated config file
 	>"$CONFIGFILE"
@@ -202,6 +205,12 @@ start_service() {
 	for f in "$OTHERCONFIGDIR"/*.conf; do
 		[ -f "$f" ] && cat "$f" >> "$CONFIGFILE"
 	done
+
+	# Import temporary config files
+	for f in "$TMPCONFIGDIR"/*.conf; do
+		[ -f "$f" ] && cat "$f" >> "$CONFIGFILE"
+	done
+	rm -rf "$TMPCONFIGDIR"
 
 	procd_open_instance
 	# Using multiple config files is supported since babeld 1.5.1

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -116,7 +116,11 @@ babel_config_cb() {
 	{
 		local _ignored
 		config_get_bool _ignored "$section" 'ignore' 0
-		[ "$_ignored" == "1" ] && return
+		[ "$_ignored" == "1" ] &&
+		{
+			option_cb() { return; }
+			return
+		}
 
 		local _ifname
 		config_get _ifname "$section" 'ifname'

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -227,10 +227,6 @@ start_service() {
 	procd_close_instance
 }
 
-stop_service() {
-	killall -9 babeld
-}
-
 service_triggers() {
 	procd_add_reload_trigger babeld
 }

--- a/babeld/files/babeld.init
+++ b/babeld/files/babeld.init
@@ -113,34 +113,39 @@ babel_config_cb() {
 		}
 	;;
 	"interface")
+	{
+		local _ignored
+		config_get_bool _ignored "$section" 'ignore' 0
+		[ "$_ignored" == "1" ] && return
+
 		local _ifname
 		config_get _ifname "$section" 'ifname'
+
 		# Try to resolve the logical interface name
-		unset interface
+		local interface
 		network_get_device interface "$_ifname" || interface="$_ifname"
-		option_cb() {
+
+		# Ignore section if ifname is not provided
+		[ -z "$interface" ] &&
+		{
+			logger -s -t babeld "Ignoring interface section which miss ifname"
+			return
+		}
+
+		interfaceFile="${OTHERCONFIGDIR}/interface_$interface.conf"
+		echo "interface $interface" > "$interfaceFile"
+
+		option_cb()
+		{
 			local option="$1"
 			local value="$2"
-			local _interface
+
 			# "option ifname" is a special option, don't actually
 			# generate configuration for it.
-			[ "$option" = "ifname" ] && return
-			[ -n "$interface" ] && _interface="interface $interface" || _interface="default"
-			cfg_append "$_interface ${option//_/-} $value"
+			[ "$option" == "ifname" ] && return
+			echo "$(cat $interfaceFile) ${option//_/-} $value" > "$interfaceFile"
 		}
-		# Handle ignore options.
-		local _ignored
-		# This works because we loaded the whole configuration
-		# beforehand (see config_load below).
-		config_get_bool _ignored "$section" 'ignore' 0
-		if [ "$_ignored" -eq 1 ]
-		then
-			option_cb() { return; }
-		else
-			# Also include an empty "interface $interface" statement,
-			# so that babeld operates on this interface.
-			[ -n "$interface" ] && cfg_append "interface $interface"
-		fi
+	}
 	;;
 	*)
 		# Don't use reset_cb, this would also reset config_cb


### PR DESCRIPTION
Without this PR the interface configuration lines are duplicated for each option, probably causing the options to not be properly applied to each interface. This PR commit solve the issue.