### PR TITLE
babeld: Add latest patches from babeld-1.8-branch

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.8.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/patches/0001-kernel_netlink-Convert-src_plen-to-v4mapped-encoding.patch
+++ b/babeld/patches/0001-kernel_netlink-Convert-src_plen-to-v4mapped-encoding.patch
@@ -1,0 +1,30 @@
+From: Fabian Bläse <fabian@blaese.de>
+Date: Wed, 26 Dec 2018 00:44:29 +0100
+Subject: kernel_netlink: Convert src_plen to v4mapped encoding on import
+
+src_plen for IPv4 routes imported from kernel has not been adjusted
+to v4mapped encoding. Therefore IPv4 xroutes used an inconsistent encoding
+which lead to failed comparisons when sending updates.
+
+Routes received from neighbors with the same prefix as xroutes therefore
+have been announced to neighbours instead.
+
+This issue is fixed by converting src_plen on import.
+
+Signed-off-by: Fabian Bläse <fabian@blaese.de>
+
+diff --git a/kernel_netlink.c b/kernel_netlink.c
+index 76e6350..8065ed6 100644
+--- a/kernel_netlink.c
++++ b/kernel_netlink.c
+@@ -1102,6 +1102,7 @@ parse_kernel_route_rta(struct rtmsg *rtm, int len, struct kernel_route *route)
+         v4tov6(route->prefix, zeroes);
+         v4tov6(route->src_prefix, zeroes);
+         route->plen = 96;
++        route->src_plen = 96;
+     }
+     route->proto = rtm->rtm_protocol;
+ 
+-- 
+2.11.0
+

--- a/babeld/patches/0002-Add-missing-add_filter-when-parsing-install-filters.patch
+++ b/babeld/patches/0002-Add-missing-add_filter-when-parsing-install-filters.patch
@@ -1,0 +1,21 @@
+From: Killian Lufau <killian.lufau@nexedi.com>
+Date: Tue, 12 Mar 2019 15:10:59 +0100
+Subject: Add missing add_filter when parsing install filters.
+
+It was removed by accident in commit ce457a7929dfcd94f007e2948150527e2410d247.
+
+diff --git a/configuration.c b/configuration.c
+index 2b18638..d1f3d9c 100644
+--- a/configuration.c
++++ b/configuration.c
+@@ -1026,6 +1026,7 @@ parse_config_line(int c, gnc_t gnc, void *closure,
+         c = parse_filter(c, gnc, closure, &filter);
+         if(c < -1)
+             goto fail;
++        add_filter(filter, &install_filters);
+     } else if(strcmp(token, "interface") == 0) {
+         struct interface_conf *if_conf;
+         c = parse_ifconf(c, gnc, closure, &if_conf);
+-- 
+2.11.0
+


### PR DESCRIPTION
Since there has been quite a while since the last babeld release
just pull the latest patches from the 1.8 branch.

I am using this for 1-2 months in production now (based on openwrt-18.06 branch).

Will send backports for 19.07 and 18.06 in case this one is accepted.