### PR TITLE
nodogsplash: Release 4.0.0

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=3.3.2
+PKG_VERSION:=4.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=5a7b14dd2cce6a8ca261a720d87948565fc2f05d4926bf155b9e0db483ff6bcb
+PKG_HASH:=4cc3a9200380f03c8c3a71afc1fda0006b8e7bf70129f2419768a767b734da21
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -60,6 +60,7 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/nodogsplash/login.sh
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/nodogsplash/
 endef
 
 define Package/nodogsplash/postrm


### PR DESCRIPTION
Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested on snapshot SDK mips_24kc and arm_cortex-a5_neon-vfpv4/

  * Introduce aes encryption of the query string passed to remote FAS, allowing authdir and client token to be transferred securely. Uses php-cli and php-openssl. These are required if encryption is enabled but are not dependencies [bluewavenet]
  * Introduce fasremotefqdn, specifying the FQDN of the remote FAS. This facilitates simplified support for FAS operation on shared hosting systems [bluewavenet]
  * Add a FAS php script supporting aes encrypted query string sent from NDS [bluewavenet]
  * Numerous Documentation updates [bluewavenet]
  * Remove unused pagesdir and imagesdir [mwarning]
  * Add Preauth script that displays images from remote servers [bluewavenet]
  * Use elegant check for valid ip addresses [mwarning]
  * openwrt initscript - add missing macmechanism in the config file [lynxis]

Signed-off-by: Rob White `<rob@blue-wave.net>`