### PR TITLE
cjdns-tests: Don't build on ARC

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -56,7 +56,7 @@ define Package/cjdns-tests
 	TITLE:=cjdns test cases
 	URL:=https://github.com/cjdelisle/cjdns
 	MAINTAINER:=Lars Gierth <larsg@systemli.org>
-	DEPENDS:=+libpthread +librt
+	DEPENDS:=+libpthread +librt @!arc
 endef
 
 define Package/cjdns-test/description


### PR DESCRIPTION
Not supported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

https://downloads.openwrt.org/snapshots/faillogs/arc_archs/routing/cjdns/compile.txt