### PR TITLE
batman-adv: Readd Linux 4.19.x compat patches

### DIFF
--- a/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch
+++ b/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch
@@ -1,0 +1,55 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 23 May 2019 19:26:27 +0200
+Subject: Revert "batman-adv: convert stream-like files from nonseekable_open -> stream_open"
+
+OpenWrt's mac80211 package is not yet ready to support the generic netlink
+API of Linux 5.2.
+
+This reverts commit 337ae19a00d4455cf84afa58abfb432f78c882b9.
+
+diff --git a/compat-include/linux/fs.h b/compat-include/linux/fs.h
+index 480722f04ba7ddefc837d5e55a340271e0814b14..c52e0e8e87584d106ab64ef2c522e6ac1ff6e796 100644
+--- a/compat-include/linux/fs.h
++++ b/compat-include/linux/fs.h
+@@ -31,15 +31,4 @@ static inline struct dentry *batadv_file_dentry(const struct file *file)
+ 
+ #endif /* < KERNEL_VERSION(4, 6, 0) */
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+-
+-static inline int batadv_stream_open(struct inode *inode, struct file *filp)
+-{
+-	return nonseekable_open(inode, filp);
+-}
+-
+-#define stream_open batadv_stream_open
+-
+-#endif /* < KERNEL_VERSION(5, 2, 0) */
+-
+ #endif	/* _NET_BATMAN_ADV_COMPAT_LINUX_FS_H_ */
+diff --git a/net/batman-adv/icmp_socket.c b/net/batman-adv/icmp_socket.c
+index 0a91c8661357d4ddbea1ba20dcd0df67b8ba5a97..de81b5ecad91afd8d684edbf781c70a3bae38c60 100644
+--- a/net/batman-adv/icmp_socket.c
++++ b/net/batman-adv/icmp_socket.c
+@@ -65,7 +65,7 @@ static int batadv_socket_open(struct inode *inode, struct file *file)
+ 
+ 	batadv_debugfs_deprecated(file, "");
+ 
+-	stream_open(inode, file);
++	nonseekable_open(inode, file);
+ 
+ 	socket_client = kmalloc(sizeof(*socket_client), GFP_KERNEL);
+ 	if (!socket_client) {
+diff --git a/net/batman-adv/log.c b/net/batman-adv/log.c
+index f79ebd5b46e95b3b6de717c7ea1ecf44e5c96051..60ce11e16a905e790424a2d7aca81c1f945c1ec2 100644
+--- a/net/batman-adv/log.c
++++ b/net/batman-adv/log.c
+@@ -90,7 +90,7 @@ static int batadv_log_open(struct inode *inode, struct file *file)
+ 	batadv_debugfs_deprecated(file,
+ 				  "Use tracepoint batadv:batadv_dbg instead\n");
+ 
+-	stream_open(inode, file);
++	nonseekable_open(inode, file);
+ 	file->private_data = inode->i_private;
+ 	return 0;
+ }

--- a/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch
+++ b/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch
@@ -1,0 +1,29 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 23 May 2019 19:26:36 +0200
+Subject: Revert "batman-adv: compat: Drop support for genl_ops->start"
+
+OpenWrt's mac80211 package is not yet ready to support the generic netlink
+API of Linux 5.2.
+
+This reverts commit 1d30dbe3917d0d6fdb8ba473dfdd6265ac46670b.
+
+diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
+index ee5b82288be97193c1a8e8340a2ea7e0c7ce112c..fbfdb733a3dd63c251def43cae416c7fe32cadab 100644
+--- a/compat-include/net/genetlink.h
++++ b/compat-include/net/genetlink.h
+@@ -42,6 +42,7 @@ enum genl_validate_flags {
+ struct batadv_genl_ops {
+ 	int		       (*doit)(struct sk_buff *skb,
+ 				       struct genl_info *info);
++	int		       (*start)(struct netlink_callback *cb);
+ 	int		       (*dumpit)(struct sk_buff *skb,
+ 					 struct netlink_callback *cb);
+ 	int		       (*done)(struct netlink_callback *cb);
+@@ -104,6 +105,7 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+ 
+ 	for (i = 0; i < family->family.n_ops; i++) {
+ 		ops[i].doit = family->ops[i].doit;
++		ops[i].start = family->ops[i].start;
+ 		ops[i].dumpit = family->ops[i].dumpit;
+ 		ops[i].done = family->ops[i].done;
+ 		ops[i].cmd = family->ops[i].cmd;

--- a/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch
+++ b/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch
@@ -1,0 +1,222 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 23 May 2019 19:26:45 +0200
+Subject: Revert "batman-adv: genetlink: optionally validate strictly/dumps"
+
+OpenWrt's mac80211 package is not yet ready to support the generic netlink
+API of Linux 5.2.
+
+This reverts commit 2ee47abaeb35ca62bb909830e10b0e973393b853.
+
+diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
+index fbfdb733a3dd63c251def43cae416c7fe32cadab..7d17a705273650355f074788e9220fc4981b0db1 100644
+--- a/compat-include/net/genetlink.h
++++ b/compat-include/net/genetlink.h
+@@ -33,25 +33,6 @@ void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+ 
+-enum genl_validate_flags {
+-	GENL_DONT_VALIDATE_STRICT		= BIT(0),
+-	GENL_DONT_VALIDATE_DUMP			= BIT(1),
+-	GENL_DONT_VALIDATE_DUMP_STRICT		= BIT(2),
+-};
+-
+-struct batadv_genl_ops {
+-	int		       (*doit)(struct sk_buff *skb,
+-				       struct genl_info *info);
+-	int		       (*start)(struct netlink_callback *cb);
+-	int		       (*dumpit)(struct sk_buff *skb,
+-					 struct netlink_callback *cb);
+-	int		       (*done)(struct netlink_callback *cb);
+-	u8			cmd;
+-	u8			internal_flags;
+-	u8			flags;
+-	u8			validate;
+-};
+-
+ struct batadv_genl_family {
+ 	/* data handled by the actual kernel */
+ 	struct genl_family family;
+@@ -69,7 +50,7 @@ struct batadv_genl_family {
+ 			 struct genl_info *info);
+         void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+ 			  struct genl_info *info);
+-	const struct batadv_genl_ops *ops;
++	const struct genl_ops *ops;
+ 	const struct genl_multicast_group *mcgrps;
+ 	unsigned int n_ops;
+ 	unsigned int n_mcgrps;
+@@ -82,6 +63,8 @@ struct batadv_genl_family {
+ 	struct genl_ops *copy_ops;
+ };
+ 
++#define genl_family batadv_genl_family
++
+ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+ {
+ 	struct genl_ops *ops;
+@@ -99,20 +82,12 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+ 	family->family.n_mcgrps = family->n_mcgrps;
+ 	family->family.module = family->module;
+ 
+-	ops = kzalloc(sizeof(*ops) * family->n_ops, GFP_KERNEL);
++	ops = kmemdup(family->ops, sizeof(*ops) * family->n_ops, GFP_KERNEL);
+ 	if (!ops)
+ 		return -ENOMEM;
+ 
+-	for (i = 0; i < family->family.n_ops; i++) {
+-		ops[i].doit = family->ops[i].doit;
+-		ops[i].start = family->ops[i].start;
+-		ops[i].dumpit = family->ops[i].dumpit;
+-		ops[i].done = family->ops[i].done;
+-		ops[i].cmd = family->ops[i].cmd;
+-		ops[i].internal_flags = family->ops[i].internal_flags;
+-		ops[i].flags = family->ops[i].flags;
++	for (i = 0; i < family->family.n_ops; i++)
+ 		ops[i].policy = family->policy;
+-	}
+ 
+ 	family->family.ops = ops;
+ 	family->copy_ops = ops;
+@@ -120,17 +95,6 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+ 	return genl_register_family(&family->family);
+ }
+ 
+-typedef struct genl_ops batadv_genl_ops_old;
+-
+-#define batadv_pre_doit(__x, __y, __z) \
+-	batadv_pre_doit(const batadv_genl_ops_old *ops, __y, __z)
+-
+-#define batadv_post_doit(__x, __y, __z) \
+-	batadv_post_doit(const batadv_genl_ops_old *ops, __y, __z)
+-
+-#define genl_ops batadv_genl_ops
+-#define genl_family batadv_genl_family
+-
+ #define genl_register_family(family) \
+ 	batadv_genl_register_family((family))
+ 
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index a67720fad46ca496c932c0306e2f7ec4ed496fc9..e7907308b331ddc3e4917ff7d648bca27a65536b 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -1343,34 +1343,29 @@ static void batadv_post_doit(const struct genl_ops *ops, struct sk_buff *skb,
+ static const struct genl_ops batadv_netlink_ops[] = {
+ 	{
+ 		.cmd = BATADV_CMD_GET_MESH,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		/* can be retrieved by unprivileged users */
+ 		.doit = batadv_netlink_get_mesh,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_TP_METER,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.doit = batadv_netlink_tp_meter_start,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_TP_METER_CANCEL,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.doit = batadv_netlink_tp_meter_cancel,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_algo_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_HARDIF,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		/* can be retrieved by unprivileged users */
+ 		.dumpit = batadv_netlink_dump_hardif,
+ 		.doit = batadv_netlink_get_hardif,
+@@ -1379,68 +1374,57 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_tt_local_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_tt_global_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_ORIGINATORS,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_orig_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_NEIGHBORS,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_hardif_neigh_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_GATEWAYS,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_gw_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_bla_claim_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_bla_backbone_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_DAT_CACHE,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_dat_cache_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.dumpit = batadv_mcast_flags_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_SET_MESH,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.doit = batadv_netlink_set_mesh,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_SET_HARDIF,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.doit = batadv_netlink_set_hardif,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+@@ -1448,7 +1432,6 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_VLAN,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		/* can be retrieved by unprivileged users */
+ 		.doit = batadv_netlink_get_vlan,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+@@ -1456,7 +1439,6 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_SET_VLAN,
+-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+ 		.flags = GENL_ADMIN_PERM,
+ 		.doit = batadv_netlink_set_vlan,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |

--- a/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch
+++ b/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch
@@ -1,0 +1,256 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 23 May 2019 19:26:58 +0200
+Subject: Revert "batman-adv: genetlink: make policy common to family"
+
+OpenWrt's mac80211 package is not yet ready to support the generic netlink
+API of Linux 5.2.
+
+This reverts commit acfc9a214d01695d1676313ca80cfd2d9309f633.
+
+diff --git a/compat-include/linux/cache.h b/compat-include/linux/cache.h
+index 9ddda31232ed4b58efcb57dc2ee99ae82d09d6e2..efe440d11d04a1c3999649ba52058ad82e4d6bea 100644
+--- a/compat-include/linux/cache.h
++++ b/compat-include/linux/cache.h
+@@ -13,8 +13,12 @@
+ #include <linux/version.h>
+ #include_next <linux/cache.h>
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+ 
++/* hack for netlink.c which marked the family ops as ro */
++#ifdef __ro_after_init
++#undef __ro_after_init
++#endif
+ #define __ro_after_init
+ 
+ #endif /* < KERNEL_VERSION(4, 6, 0) */
+diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
+index 7d17a705273650355f074788e9220fc4981b0db1..58fc24d7147a7f79c2db1976b36351d294f2aa4c 100644
+--- a/compat-include/net/genetlink.h
++++ b/compat-include/net/genetlink.h
+@@ -30,92 +30,4 @@ void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
+ 
+ #endif /* < KERNEL_VERSION(4, 15, 0) */
+ 
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+-
+-struct batadv_genl_family {
+-	/* data handled by the actual kernel */
+-	struct genl_family family;
+-
+-	/* data which has to be copied to family by
+-	 * batadv_genl_register_family
+-	 */
+-	unsigned int hdrsize;
+-	char name[GENL_NAMSIZ];
+-	unsigned int version;
+-	unsigned int maxattr;
+-	const struct nla_policy *policy;
+-	bool netnsok;
+-        int  (*pre_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+-			 struct genl_info *info);
+-        void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+-			  struct genl_info *info);
+-	const struct genl_ops *ops;
+-	const struct genl_multicast_group *mcgrps;
+-	unsigned int n_ops;
+-	unsigned int n_mcgrps;
+-	struct module *module;
+-
+-	/* allocated by batadv_genl_register_family and free'd by
+-	 * batadv_genl_unregister_family. Used to modify the usually read-only
+-	 * ops
+-	 */
+-	struct genl_ops *copy_ops;
+-};
+-
+-#define genl_family batadv_genl_family
+-
+-static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+-{
+-	struct genl_ops *ops;
+-	unsigned int i;
+-
+-	family->family.hdrsize = family->hdrsize;
+-	strncpy(family->family.name, family->name, sizeof(family->family.name));
+-	family->family.version = family->version;
+-	family->family.maxattr = family->maxattr;
+-	family->family.netnsok = family->netnsok;
+-	family->family.pre_doit = family->pre_doit;
+-	family->family.post_doit = family->post_doit;
+-	family->family.mcgrps = family->mcgrps;
+-	family->family.n_ops = family->n_ops;
+-	family->family.n_mcgrps = family->n_mcgrps;
+-	family->family.module = family->module;
+-
+-	ops = kmemdup(family->ops, sizeof(*ops) * family->n_ops, GFP_KERNEL);
+-	if (!ops)
+-		return -ENOMEM;
+-
+-	for (i = 0; i < family->family.n_ops; i++)
+-		ops[i].policy = family->policy;
+-
+-	family->family.ops = ops;
+-	family->copy_ops = ops;
+-
+-	return genl_register_family(&family->family);
+-}
+-
+-#define genl_register_family(family) \
+-	batadv_genl_register_family((family))
+-
+-static inline void
+-batadv_genl_unregister_family(struct batadv_genl_family *family)
+-{
+-
+-	genl_unregister_family(&family->family);
+-	kfree(family->copy_ops);
+-}
+-
+-#define genl_unregister_family(family) \
+-	batadv_genl_unregister_family((family))
+-
+-#define genlmsg_put(_skb, _pid, _seq, _family, _flags, _cmd) \
+-	genlmsg_put(_skb, _pid, _seq, &(_family)->family, _flags, _cmd)
+-
+-#define genlmsg_multicast_netns(_family, _net, _skb, _portid, _group, _flags) \
+-	genlmsg_multicast_netns(&(_family)->family, _net, _skb, _portid, \
+-				_group, _flags)
+-
+-#endif /* < KERNEL_VERSION(5, 2, 0) */
+-
+ #endif /* _NET_BATMAN_ADV_COMPAT_NET_GENETLINK_H_ */
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index e7907308b331ddc3e4917ff7d648bca27a65536b..daf56933223d478399c63360203bcf283d7686a3 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -1344,29 +1344,34 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	{
+ 		.cmd = BATADV_CMD_GET_MESH,
+ 		/* can be retrieved by unprivileged users */
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_get_mesh,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_TP_METER,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_tp_meter_start,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_TP_METER_CANCEL,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_tp_meter_cancel,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_algo_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_HARDIF,
+ 		/* can be retrieved by unprivileged users */
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_netlink_dump_hardif,
+ 		.doit = batadv_netlink_get_hardif,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+@@ -1375,57 +1380,68 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	{
+ 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_tt_local_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_tt_global_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_ORIGINATORS,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_orig_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_NEIGHBORS,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_hardif_neigh_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_GATEWAYS,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_gw_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_bla_claim_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_bla_backbone_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_DAT_CACHE,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_dat_cache_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.dumpit = batadv_mcast_flags_dump,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_SET_MESH,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_set_mesh,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH,
+ 	},
+ 	{
+ 		.cmd = BATADV_CMD_SET_HARDIF,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_set_hardif,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+ 				  BATADV_FLAG_NEED_HARDIF,
+@@ -1433,6 +1449,7 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	{
+ 		.cmd = BATADV_CMD_GET_VLAN,
+ 		/* can be retrieved by unprivileged users */
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_get_vlan,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+ 				  BATADV_FLAG_NEED_VLAN,
+@@ -1440,6 +1457,7 @@ static const struct genl_ops batadv_netlink_ops[] = {
+ 	{
+ 		.cmd = BATADV_CMD_SET_VLAN,
+ 		.flags = GENL_ADMIN_PERM,
++		.policy = batadv_netlink_policy,
+ 		.doit = batadv_netlink_set_vlan,
+ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+ 				  BATADV_FLAG_NEED_VLAN,
+@@ -1451,7 +1469,6 @@ struct genl_family batadv_netlink_family __ro_after_init = {
+ 	.name = BATADV_NL_NAME,
+ 	.version = 1,
+ 	.maxattr = BATADV_ATTR_MAX,
+-	.policy = batadv_netlink_policy,
+ 	.netnsok = true,
+ 	.pre_doit = batadv_pre_doit,
+ 	.post_doit = batadv_post_doit,


### PR DESCRIPTION
@simonwunderlich 

----

The patches were accidentally deleted while testing the batman-adv 2019.3 bugfixes with various OpenWrt versions. But OpenWrt 19.07 will be released with a mac80211 package which still uses the Linux 4.19 API. And thus the OpenWrt 19.07 openwrt-routing branch still has to retain these compat patches.

Fixes: a93e68447a55 ("alfred: Merge bugfixes from 2019.3")