### PR TITLE
nodogsplash: Release 4.0.2

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=4.0.1
+PKG_VERSION:=4.0.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=b6787d042ab65f8cdc6982bd083a28a85ac3494896ae5c97e9de9b216585b1e7
+PKG_HASH:=43761b3637742ad22a7f7a8900cb200c133d7ea0c78530014688c5dc7eb6d3c1
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested on snapshot SDK mips_24kc

This release has numerous bug fixes and enhancements:

  * Fix bug - fas_remotefqdn not supported with option fas_secure_enabled 0 [bluewavenet]
  * Fix bug - prevent deadlock causing ndsctl to hang and NDS to become unresponsive [bluewavenet]
  * PreAuth - Override FAS settings making configuration foolproof [bluewavenet]
  * ndsctl - make json parsing consistent for all client variables [bluewavenet]
  * Fix memory leak in template generation [lynxis]
  * When executing the ndsctl stop command, cleanup all structures [lynxis]
  * Check for positive errno in thread_ndsctl [lynxis]

Signed-off-by: Rob White `<rob@blue-wave.net>`