### PR TITLE
Bird: Bump package versions to 1.6.7 and 2.0.5

### DIFF
--- a/bird1/Makefile
+++ b/bird1/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird1
-PKG_VERSION:=1.6.6
+PKG_VERSION:=1.6.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=975b3b7aefbe1e0dc9c11e55517f0ca2d82cca1d544e2e926f78bc843aaf2d70
+PKG_HASH:=7eab27ff4b0117a33d20f61b161b647e1fd354b9303c4ed4d3f99260b2173dc9
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)

--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.0.4
+PKG_VERSION:=2.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=676010b7517d4159b9af37401c26185f561ffcffeba73690a2ef2fad984714de
+PKG_HASH:=4e4b736fd26579823a728be6a7746b3f525206e3c9a4a21fccb302cffd3029d3
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)


### PR DESCRIPTION
Upstream released new versions of both series of the Bird routing daemon on August 5th. Bump the package Makefiles.

Compile tested on OpenWrt 18.06 for ar71xx.