### PR TITLE
babeld: Update to 1.8.5 and slightly improve Makefile

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
-PKG_VERSION:=1.8.4
+PKG_VERSION:=1.8.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
-PKG_HASH:=98070dc418c190f047b8d69eb47987df30ded8f0fca353c49427d3137ad08b87
+PKG_HASH:=202d99c275604507c6ce133710522f1ddfb62cb671c26f1ac2d3ab44af3d5bc4
 PKG_LICENSE:=MIT
 
 include $(INCLUDE_DIR)/package.mk

--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -14,7 +14,11 @@ PKG_RELEASE:=1
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
 PKG_HASH:=202d99c275604507c6ce133710522f1ddfb62cb671c26f1ac2d3ab44af3d5bc4
+
+PKG_MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>, \
+	Baptiste Jonglez <openwrt-pkg@bitsofnetworks.org>
 PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
 
 include $(INCLUDE_DIR)/package.mk
 
@@ -24,19 +28,17 @@ define Package/babeld
   SUBMENU:=Routing and Redirection
   TITLE:=A loop-free distance-vector routing protocol
   URL:=https://www.irif.fr/~jch/software/babel/
-  MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>, \
-              Baptiste Jonglez <openwrt-pkg@bitsofnetworks.org>
   DEPENDS:=@IPV6
 endef
 
 define Package/babeld/description
- Babel is a loop-avoiding distance-vector routing protocol roughly based
- on DSDV and AODV, but with provisions for link cost estimation and
- redistribution of routes from other routing protocols.
- While it is optimised for wireless mesh networks, Babel will also work
- efficiently on wired networks. It will generate between 1.2 and 2.4 times
- the amount of routing traffic that RIPng would generate, while
- never counting to infinity.
+  Babel is a loop-avoiding distance-vector routing protocol roughly based
+  on DSDV and AODV, but with provisions for link cost estimation and
+  redistribution of routes from other routing protocols.
+  While it is optimised for wireless mesh networks, Babel will also work
+  efficiently on wired networks. It will generate between 1.2 and 2.4 times
+  the amount of routing traffic that RIPng would generate, while
+  never counting to infinity.
 endef
 
 define Package/babeld/conffiles


### PR DESCRIPTION
This bumps babeld to 1.8.5 and adds some simple improvements from https://github.com/openwrt/packages/pull/9408

Since babeld-1.8.5 just contains two "fixes", I would like to have it backported to 19.07 (I could also send a PR adding those two fixes as patches, but I think this would be useless additional work).

I will send a bump to the recent version 1.9.1 in a separate PR, as I would like to have both update steps (1.8.5 and 1.9.1) separately in master. (I have been told that 1.9 incompatibly changes treatment of some source-specific routes, so having 1.8.5 as separate patch will make switching easier ...).