### PR TITLE
nodogsplash: Release 4.1.0

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=4.0.2
+PKG_VERSION:=4.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=43761b3637742ad22a7f7a8900cb200c133d7ea0c78530014688c5dc7eb6d3c1
+PKG_HASH:=a818b75eec80159194ef19a777b032970fc18eb542fd610c5edfac4ae25c0f4b
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
nodogsplash: Release 4.1.0

Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested - snapshot SDK mips_24kc

This release adds significant functionality in addition to enhancements, documentation updates and numerous bug fixes.

  * BinAuth - Send redir variable to the binauth script, allow passing of custom variable payload [bluewavenet]
  * BinAuth - Provide two example BinAuth scripts [bluewavenet]
  * Documentation - Rework Binauth section plus numerous minor updates [bluewavenet]
  * Deprecate RedirectURL config option as it is rendered obsolete by many CPD implementations, use FAS instead [bluewavenet]
  * Numerous minor updates to html, css and script files [bluewavenet]
  * Fix bug - faskey, exit gracefully if not set and fas_secure_enabled = 2 [bluewavenet]
  * Fix bug - Systemd, Do not set debug level in nodogsplash.service [bluewavenet]
  * Fix bug - ndsctl, delete lock file if NDS is not started [bluewavenet]

Signed-off-by: Rob White `<rob@blue-wave.net>`