### PR TITLE
bmx7: fixup Makefile

### DIFF
--- a/bmx7/Makefile
+++ b/bmx7/Makefile
@@ -2,13 +2,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bmx7
 PKG_VERSION:=7.1.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://codeload.github.com/bmx-routing/bmx7/tar.gz/v$(PKG_VERSION)?
 PKG_HASH:=5f88df1c95e5cb842a6016bb1604e3e7f6097c63c5c9916edc3c84e96d4f5f65
-PKG_UNPACK:=$(TAR) -C $(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION) \
-	--strip-components=2 -xzf $(DL_DIR)/$(PKG_SOURCE) $(PKG_NAME)-$(PKG_VERSION)/src
 
 PKG_MAINTAINER:=Axel Neumann <neumann@cgws.de>
 PKG_LICENSE:=GPL-2.0-or-later
@@ -20,14 +18,22 @@ include $(INCLUDE_DIR)/package.mk
 
 TARGET_CFLAGS += $(FPIC)
 
-MAKE_ARGS += EXTRA_CFLAGS="$(TARGET_CFLAGS) -I. -I$(STAGING_DIR)/usr/include -DCRYPTLIB=MBEDTLS_2_8_0 -DCORE_LIMIT=20000 -DTRAFFIC_DUMP -DNO_TRACE_FUNCTION_CALLS -DBMX7_LIB_IWINFO"
+MAKE_ARGS += EXTRA_CFLAGS="$(TARGET_CFLAGS) \
+				-I. \
+				-I$(STAGING_DIR)/usr/include \
+				-DCRYPTLIB=MBEDTLS_2_8_0 \
+				-DCORE_LIMIT=20000 \
+				-DTRAFFIC_DUMP \
+				-DNO_TRACE_FUNCTION_CALLS \
+				-DBMX7_LIB_IWINFO" \
+				EXTRA_LDFLAGS="$(TARGET_LDFLAGS) \
+			 	-L$(STAGING_DIR)/usr/lib -liwinfo" \
+				GIT_REV="$(PKG_REV)" \
+				CC="$(TARGET_CC)" \
+				INSTALL_DIR="$(PKG_INSTALL_DIR)" \
+				build_all
 
-MAKE_ARGS += \
-        EXTRA_LDFLAGS="$(TARGET_LDFLAGS) -L$(STAGING_DIR)/usr/lib -liwinfo" \
-        GIT_REV="$(PKG_REV)" \
-        CC="$(TARGET_CC)" \
-        INSTALL_DIR="$(PKG_INSTALL_DIR)" \
-        build_all
+MAKE_PATH:=src
 
 define Package/bmx7/Default
   SECTION:=net
@@ -89,29 +95,14 @@ define Package/bmx7-table
   TITLE:=plugin to announce routes from tables via tunnels
 endef
 
-define Build/Configure
-	mkdir -p $(PKG_INSTALL_DIR)
+define Package/bmx7/install
+	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/bmx7 $(1)/usr/sbin/bmx7
 endef
 
 define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR) $(MAKE_ARGS)
+       $(MAKE) -C $(PKG_BUILD_DIR)/$(MAKE_PATH) $(MAKE_ARGS)
 endef
-
-define Package/bmx7/install
-	$(INSTALL_DIR) $(1)/usr/sbin $(1)/etc/config $(1)/etc/init.d
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/bmx7 $(1)/usr/sbin/bmx7
-endef
-
-define Package/bmx7/postinst
-#!/bin/sh
-# # check if we are on real system
-if [ -z "$${IPKG_INSTROOT}" ]; then
-	if [ -f /etc/sysupgrade.conf ] && ! grep bmx7 /etc/sysupgrade.conf; then
-		echo /etc/bmx7 >> /etc/sysupgrade.conf
-        fi
-fi
-endef
-
 
 define Package/bmx7-uci-config/conffiles
 /etc/config/bmx7
@@ -120,39 +111,46 @@ endef
 
 define Package/bmx7-uci-config/install
 	$(INSTALL_DIR) $(1)/usr/lib $(1)/etc/config $(1)/etc/init.d
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_uci_config/bmx7_config.so $(1)/usr/lib/bmx7_config.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_uci_config/bmx7_config.so \
+		$(1)/usr/lib/bmx7_config.so
 	$(INSTALL_BIN) ./files/etc/init.d/bmx7 $(1)/etc/init.d/bmx7
 	$(INSTALL_DATA) ./files/etc/config/bmx7 $(1)/etc/config/bmx7
 endef
 
 define Package/bmx7-iwinfo/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_iwinfo/bmx7_iwinfo.so $(1)/usr/lib/bmx7_iwinfo.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_iwinfo/bmx7_iwinfo.so \
+		$(1)/usr/lib/bmx7_iwinfo.so
 endef
 
 define Package/bmx7-topology/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_topology/bmx7_topology.so $(1)/usr/lib/bmx7_topology.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_topology/bmx7_topology.so \
+		$(1)/usr/lib/bmx7_topology.so
 endef
 
 define Package/bmx7-json/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_json/bmx7_json.so $(1)/usr/lib/bmx7_json.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_json/bmx7_json.so \
+		$(1)/usr/lib/bmx7_json.so
 endef
 
 define Package/bmx7-sms/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_sms/bmx7_sms.so $(1)/usr/lib/bmx7_sms.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_sms/bmx7_sms.so \
+		$(1)/usr/lib/bmx7_sms.so
 endef
 
 define Package/bmx7-tun/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_tun/bmx7_tun.so $(1)/usr/lib/bmx7_tun.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_tun/bmx7_tun.so \
+		$(1)/usr/lib/bmx7_tun.so
 endef
 
 define Package/bmx7-table/install
 	$(INSTALL_DIR) $(1)/usr/lib
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/lib/bmx7_table/bmx7_table.so $(1)/usr/lib/bmx7_table.so
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/$(MAKE_PATH)/lib/bmx7_table/bmx7_table.so \
+		$(1)/usr/lib/bmx7_table.so
 endef
 
 $(eval $(call BuildPackage,bmx7))


### PR DESCRIPTION
The extra MAKE_ARGS were no longer taken into account resulting in
erros. Also more path fixes and some longline splitting.

Signed-off-by: Paul Spooren <mail@aparcar.org>