### PR TITLE
nodogsplash: Release 4.2.0

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=4.0.2
+PKG_VERSION:=4.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=43761b3637742ad22a7f7a8900cb200c133d7ea0c78530014688c5dc7eb6d3c1
+PKG_HASH:=75f559b28a1443b2ecaa95c0cb98610372d558324c8d2f003a8ebe22185b81c0
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
nodogsplash: Release 4.2.0

Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested on snapshot SDK mips_24kc and arm_cortex-a7_neon-vfpv4

This release adds significant functionality in the form of capturing the client User-Agent string and passing to both PreAuth and BinAuth scripts. Compatibility is maintained with previous versions.

Changelog since last OpenWrt release:

 * BinAuth - Send User Agent string and client-ip to the binauth script [bluewavenet]
 * BinAuth - Update the two example BinAuth scripts showing use of passed arguments [bluewavenet]
 * Documentation - Update BinAuth section [bluewavenet]
 * PreAuth - Send User Agent string to the preauth script [bluewavenet]
 * PreAuth - Update the example PreAuth script showing use of passed arguments [bluewavenet]
 * Documentation - Update PreAuth section [bluewavenet]
 * BinAuth - Send redir variable to the binauth script, allow passing of custom variable payload [bluewavenet]
 * BinAuth - Provide two example BinAuth scripts [bluewavenet]
 * Documentation - Rework Binauth section plus numerous minor updates [bluewavenet]
 * Deprecate RedirectURL config option as it is rendered obsolete by many CPD implementations, use FAS instead [bluewavenet]
 * Numerous minor updates to html, css and script files [bluewavenet]
 * Fix bug - faskey, exit gracefully if not set and fas_secure_enabled = 2 [bluewavenet]
 * Fix bug - Systemd, Do not set debug level in nodogsplash.service [bluewavenet]
 * Fix bug - ndsctl, delete lock file if NDS is not started [bluewavenet]

Signed-off-by: Rob White `<rob@blue-wave.net>`