### PR TITLE
bird{1,2}: Update to version 1.6.8 and 2.0.6

### DIFF
--- a/bird1/Makefile
+++ b/bird1/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird1
-PKG_VERSION:=1.6.7
+PKG_VERSION:=1.6.8
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=7eab27ff4b0117a33d20f61b161b647e1fd354b9303c4ed4d3f99260b2173dc9
+PKG_HASH:=6c61ab5d2ef59d2559a8735b8252b5a0238013b43e5fb8a96c5d9d06e7bc00b2
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Álvaro Fernández Rojas <noltari@gmail.com>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)

--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.0.5
+PKG_VERSION:=2.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=4e4b736fd26579823a728be6a7746b3f525206e3c9a4a21fccb302cffd3029d3
+PKG_HASH:=90934cce6ae90039ab1e58ade223935f9221a7e5eac05df6fb53045b77bfd3aa
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)


### PR DESCRIPTION
Maintainer: @Noltari and @tohojo 
Compile tested: mvebu, Turris Omnia, OpenWrt master.

Changelog:
[Version 2.0.6 (2019-09-10)](https://gitlab.labs.nic.cz/labs/bird/blob/v2.0.6/NEWS)
  o RAdv: Solicited unicast RAs
  o BGP: Optional Adj-RIB-Out
  o BGP: Extended optional parameters length
  o Filter: Sets and set expressions in path masks
  o Several important bugfixes

[Version 1.6.8 (2019-09-10)](https://gitlab.labs.nic.cz/labs/bird/blob/v1.6.8/NEWS)
  o Several important bugfixes