### PR TITLE
nodogsplash: Version 4.3.0

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=4.2.0
+PKG_VERSION:=4.3.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=75f559b28a1443b2ecaa95c0cb98610372d558324c8d2f003a8ebe22185b81c0
+PKG_HASH:=9a3fa68f154627169832aa986ba32ca6a25f345d7e81737835b0044764cd670b
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
nodogsplash: Version 4.3.0

Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested on snapshot SDK mips_24kc and arm_cortex-a7_neon-vfpv4

This release has major new functionality in the form of token hashing, (extension to fas_secure level-1) mitigating the problems with remote FAS where access to the local ndsctl would be otherwise required.
Although not as flexible as level 2, this extension has much smaller memory and storage requirements so is ideal for implementation on legacy hardware.

There are also numerous enhancements, updates and fixes.

All changes are compatible with the previous release.

Latest changelog:

 * Create switch option to select preinstalled templated splash or preauth login [bluewavenet]
 * Limit PreAuth and BinAuth log size in example scripts [bluewavenet]
 * Reduce memory requirements and autoselect logfile location [bluewavenet]
 * Create fas-hid example script [bluewavenet]
 * Update FAS, PreAuth and BinAuth example scripts [bluewavenet]
 * Hash client token (hid) for remote FAS enabling secure FAS for legacy/low-flash/low-ram hardware [bluewavenet]
 * Fix NDS Uptime if NTP client is enabled [bluewavenet]
 * Documentation updates for this release [bluewavenet]
 * Fix numerous compiler warnings [mwarning]
 * Fix openwrt fw_mark option type [mwarning]

Signed-off-by: Rob White `<rob@blue-wave.net>`