### PR TITLE
ahcpd: Replace PKG_MD5SUM with PKG_HASH

### DIFF
--- a/ahcpd/Makefile
+++ b/ahcpd/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.pps.univ-paris-diderot.fr/~jch/software/files/
-PKG_MD5SUM:=a1a610bf20965aa522cd766bf3d5829a
+PKG_HASH:=a1a610bf20965aa522cd766bf3d5829a
 PKG_LICENSE:=MIT
 
 


### PR DESCRIPTION
PKG_MD5SUM is deprecated and does not accurately represent the SHA256 hash.

Signed-off-by: Rosen Penev <rosenp@gmail.com>