### PR TITLE
cjdns: luci-app-cjdns: update maintainer

### DIFF
--- a/cjdns/Makefile
+++ b/cjdns/Makefile
@@ -37,7 +37,7 @@ define Package/cjdns
 	SUBMENU:=Routing and Redirection
 	TITLE:=Encrypted near-zero-conf mesh routing protocol
 	URL:=https://github.com/cjdelisle/cjdns
-	MAINTAINER:=Lars Gierth <larsg@systemli.org>
+	MAINTAINER:=William Fleurant <meshnet@protonmail.com>
 	DEPENDS:=@!arc @IPV6 +kmod-tun +libnl-tiny +libpthread +librt \
 		+libuci-lua +lua-bencode +dkjson +luasocket +lua-sha2
 endef

--- a/luci-app-cjdns/Makefile
+++ b/luci-app-cjdns/Makefile
@@ -30,7 +30,7 @@ define Package/luci-app-cjdns
 	SUBMENU:=3. Applications
 	TITLE:=Encrypted near-zero-conf mesh routing protocol
 	URL:=https://github.com/cjdelisle/cjdns
-	MAINTAINER:=Lars Gierth <larsg@systemli.org>
+	MAINTAINER:=William Fleurant <meshnet@protonmail.com>
 	DEPENDS:=+cjdns +luci-base
 endef
 


### PR DESCRIPTION
> Changes like correcting md5sums, changing mirror URLs, adding a maintainer field or updating a comment or copyright year in a Makefile do not require a change to PKG_RELEASE

> maintainer change see #398

Signed-off-by: William Fleurant <meshnet@protonmail.com>