### PR TITLE
batman-adv and friends: improve version string

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -59,7 +59,7 @@ MAKE_FLAGS += \
 	CONFIG_ALFRED_CAPABILITIES=n \
         LIBNL_NAME="libnl-tiny" \
         LIBNL_GENL_NAME="libnl-tiny" \
-        REVISION="openwrt-$(PKG_VERSION)-$(PKG_RELEASE)"
+        REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
 
 TARGET_CFLAGS  += -ffunction-sections -fdata-sections -flto
 TARGET_LDFLAGS += -Wl,--gc-sections -fuse-linker-plugin

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -94,7 +94,7 @@ MAKE_VARS += \
         LIBNL_GENL_NAME="libnl-tiny"
 
 MAKE_FLAGS += \
-        REVISION="openwrt-$(PKG_VERSION)-$(PKG_RELEASE)"
+        REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
 
 config-n := \
 	aggregation \

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -76,7 +76,7 @@ NOSTDINC_FLAGS = \
 	-I$(PKG_BUILD_DIR)/include/ \
 	-include backport/backport.h \
 	-include $(PKG_BUILD_DIR)/compat-hacks.h \
-	-DBATADV_SOURCE_VERSION=\\\"openwrt-$(PKG_VERSION)-$(PKG_RELEASE)\\\"
+	-DBATADV_SOURCE_VERSION=\\\"$(PKG_VERSION)-openwrt-$(PKG_RELEASE)\\\"
 
 COMPAT_SOURCES = \
 	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \


### PR DESCRIPTION
This changes the package version string so it does not start
with "openwrt", but with the base version we are modifying:

So far: openwrt-2019.4-1
Now:    2019.4-openwrt-1

Since it's us modifying version 2019.4 (in this case), this order
is more convenient (and also closer to what the kernel version
string does).