### PR TITLE
luci-app-cjdns: Add luci-compat requirement

### DIFF
--- a/luci-app-cjdns/Makefile
+++ b/luci-app-cjdns/Makefile
@@ -31,7 +31,7 @@ define Package/luci-app-cjdns
 	SUBMENU:=3. Applications
 	TITLE:=Encrypted near-zero-conf mesh routing protocol
 	URL:=https://github.com/cjdelisle/cjdns
-	DEPENDS:=+cjdns +luci-base
+	DEPENDS:=+cjdns +luci-compat +luci-base
 endef
 
 define Package/luci-app-cjdns/description


### PR DESCRIPTION
After https://github.com/openwrt/luci/commit/284918bfaf2f6d7e46fb11377bb9a537b35dd58a commit in openwrt/luci, every app which uses cbi requires luci-compat package.