### PR TITLE
[OpenWrt 19.07] nodogsplash: Backport Version 4.4.0

### DIFF
--- a/nodogsplash/Makefile
+++ b/nodogsplash/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=4.0.1
+PKG_VERSION:=4.4.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=b6787d042ab65f8cdc6982bd083a28a85ac3494896ae5c97e9de9b216585b1e7
+PKG_HASH:=6f309847f36be85cdbdd2f940f44791c53c64657fa8253c6318f913da95c1e9c
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>
@@ -60,6 +60,8 @@ define Package/nodogsplash/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/etc/uci-defaults/40_nodogsplash $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/nodogsplash/files/usr/lib/nodogsplash/restart.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/nodogsplash/login.sh
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/nodogsplash/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/nodogsplash/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/nodogsplash/
 endef
 


### PR DESCRIPTION
Maintainer: Moritz Warning `<moritzwarning@web.de>`

Compiled and tested on mips_24kc and arm_cortex-a7_neon-vfpv4

This release adds significant new functionality yet is compatible with the previous version.

From the changelog:

 * Add Client Network Zone detection supporting local interfaces and 802.11s mesh [bluewavenet]
 * Add client zone and user agent to FAS/PreAuth logs [bluewavenet]
 * Add requirements for retrieving https remote image for login page [bluewavenet]
 * Add htmlentity encode and decode to preauth scripts [bluewavenet]
 * Implement unescape callback for MHD allowing url special characters to be used in login forms [bluewavenet]
 * Create get_client_interface library utility [bluewavenet]
 * Create unescape library utility [bluewavenet]
 * Update demo-preauth, login-option and fas scripts [bluewavenet]
 * Update fwhook restart - do not use ndsctl to check if nds is running [bluewavenet]
 * Update config files [bluewavenet]
 * Fix - allow comma space to be used in PreAuth variables [bluewavenet]
 * Fix - final redirect for fas-aes [bluewavenet]
 * Fix - ignore trusted mac if invalid [bluewavenet]
 * Documentation updates [bluewavenet]

Signed-off-by: Rob White `<rob@blue-wave.net>`