### PR TITLE
bird2: fix service restart and reload

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
 PKG_VERSION:=2.0.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird

--- a/bird2/files/bird.init
+++ b/bird2/files/bird.init
@@ -11,10 +11,14 @@ BIRD_PID_FILE="/var/run/bird.pid"
 start_service() {
     mkdir -p /var/run
     procd_open_instance
-    procd_set_param command $BIRD_BIN -c $BIRD_CONF -P $BIRD_PID_FILE
+    procd_set_param command $BIRD_BIN -f -c $BIRD_CONF -P $BIRD_PID_FILE
     procd_set_param file "$BIRD_CONF"
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_set_param respawn
     procd_close_instance
+}
+
+reload_service() {
+    procd_send_signal bird
 }


### PR DESCRIPTION
`/etc/init.d/bird restart` or `/etc/init.d/bird reload` has no effects.

This PR fixes this issue by:

- running the service in the foreground to meet the requirements of procd
- sending SIGHUP signal to reload the service