### PR TITLE
luci-app-bmx6: bugfix format to query bmx6-info

### DIFF
--- a/luci-app-bmx6/Makefile
+++ b/luci-app-bmx6/Makefile
@@ -20,7 +20,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-bmx6
-PKG_RELEASE:=5
+PKG_RELEASE:=6
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
 PKG_LICENSE:=GPL-2.0+

--- a/luci-app-bmx6/bmx6/usr/lib/lua/luci/view/bmx6/nodes_j.htm
+++ b/luci-app-bmx6/bmx6/usr/lib/lua/luci/view/bmx6/nodes_j.htm
@@ -87,7 +87,7 @@
 		  document.getElementById('extra-info').innerHTML = document.getElementById(id).innerHTML;
 		}
 	
-		new TablePooler(5,"/cgi-bin/bmx6-info", {'$neighbours':''}, "descriptions_table", function(st){
+		new TablePooler(5,"/cgi-bin/bmx6-info", {'neighbours':''}, "descriptions_table", function(st){
 	  	  var infoicon = "<%=resource%>/bmx6/world_small.png";
 		  var nodeicon = "<%=resource%>/bmx6/world.png";
 	  	  var originators = st.neighbours[0].originators;

--- a/luci-app-bmx6/bmx6/usr/lib/lua/luci/view/bmx6/status_j.htm
+++ b/luci-app-bmx6/bmx6/usr/lib/lua/luci/view/bmx6/status_j.htm
@@ -63,7 +63,7 @@ Visit <a href="http://bmx6.net">bmx6.net</a> for more info.
 </div>
 
 <script type="text/javascript">//<![CDATA[
-		new TablePooler(5,"/cgi-bin/bmx6-info", {'$info':''}, "status_table", function(st){
+		new TablePooler(5,"/cgi-bin/bmx6-info", {'info':''}, "status_table", function(st){
 		var res = Array();
 		var sta = st.info[0].status;
 		var ifaces = st.info[1].interfaces;

--- a/luci-app-bmx6/bmx6/usr/lib/lua/luci/view/bmx6/tunnels_j.htm
+++ b/luci-app-bmx6/bmx6/usr/lib/lua/luci/view/bmx6/tunnels_j.htm
@@ -81,7 +81,7 @@
 </div>
 
 <script type="text/javascript">//<![CDATA[
-		new TablePooler(5,"/cgi-bin/bmx6-info", {'$tunnels':''}, "descriptions_table", function(st){
+		new TablePooler(5,"/cgi-bin/bmx6-info", {'tunnels':''}, "descriptions_table", function(st){
                   var tunicon = "<%=resource%>/icons/tunnel.png";
                   var tunicon_dis = "<%=resource%>/icons/tunnel_disabled.png";
                   var applyicon = "<%=resource%>/cbi/apply.gif";
@@ -91,7 +91,7 @@
                         var nodename = tunnel.remoteName.replace(/\..+$/,'');
 			var advnet = tunnel.advNet;
 			var status = '<img src="'+tunicon_dis+'"/>';
-			
+
 			if ( tunnel.tunName != "---" ) status = '<img src="'+tunicon+'"/>';
 			if ( advnet == "0.0.0.0/0" ) advnet = "<b>Internet</b>";
 


### PR DESCRIPTION
- affected three tab luci templates (even with luci-compat installed)
- fixes #548
- as jow said in #548:
  - it might be that modern LuCI escapes it as %24 while old versions passed it
    on as-is
  - bmx6-info removes it anyway
    https://github.com/openwrt-routing/packages/blob/master/luci-app-bmx6/bmx6/www/cgi-bin/bmx6-info#L22
you can probably just remove it in all three tab templates