### PR TITLE
[19.07] bird2: backport from master update to version 2.0.7 + fix restart&reload

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
 PKG_VERSION:=2.0.7
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird

--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.0.4
+PKG_VERSION:=2.0.5
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=676010b7517d4159b9af37401c26185f561ffcffeba73690a2ef2fad984714de
+PKG_HASH:=4e4b736fd26579823a728be6a7746b3f525206e3c9a4a21fccb302cffd3029d3
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)

--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.0.5
+PKG_VERSION:=2.0.6
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=4e4b736fd26579823a728be6a7746b3f525206e3c9a4a21fccb302cffd3029d3
+PKG_HASH:=90934cce6ae90039ab1e58ade223935f9221a7e5eac05df6fb53045b77bfd3aa
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)

--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.0.6
+PKG_VERSION:=2.0.7
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=ftp://bird.network.cz/pub/bird
-PKG_HASH:=90934cce6ae90039ab1e58ade223935f9221a7e5eac05df6fb53045b77bfd3aa
+PKG_HASH:=631d2b58aebdbd651aaa3c68c3756c02ebfe5b1e60d307771ea909eeaa5b1066
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)

--- a/bird2/files/bird.init
+++ b/bird2/files/bird.init
@@ -11,10 +11,14 @@ BIRD_PID_FILE="/var/run/bird.pid"
 start_service() {
     mkdir -p /var/run
     procd_open_instance
-    procd_set_param command $BIRD_BIN -c $BIRD_CONF -P $BIRD_PID_FILE
+    procd_set_param command $BIRD_BIN -f -c $BIRD_CONF -P $BIRD_PID_FILE
     procd_set_param file "$BIRD_CONF"
     procd_set_param stdout 1
     procd_set_param stderr 1
     procd_set_param respawn
     procd_close_instance
+}
+
+reload_service() {
+    procd_send_signal bird
 }


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: Turris 1.1, powerpc 8540, OpenWrt 19.07.

Fixes #557