### PR TITLE
opennds: Create new Package, release v5.0.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -1,0 +1,82 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=opennds
+PKG_FIXUP:=autoreconf
+PKG_VERSION:=5.0.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
+PKG_HASH:=ee31605327b515ccecbacca8404c2ae67a47357ea0201536943031f99c96fdb6
+PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=GPL-2.0+
+
+include $(INCLUDE_DIR)/package.mk
+
+
+define Package/opennds
+	SUBMENU:=Captive Portals
+	SECTION:=net
+	CATEGORY:=Network
+	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
+	TITLE:=Open public network gateway daemon
+	URL:=https://github.com/opennds/opennds
+	CONFLICTS:=nodogsplash2, nodogsplash
+endef
+
+define Package/opennds/description
+	openNDS is a Captive Portal that offers a simple way to
+	provide restricted access to the Internet by showing a splash
+	page to the user before Internet access is granted.
+	It also incorporates an API that allows the creation of
+	sophisticated authentication applications.
+endef
+
+define Package/opennds/install
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/opennds $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ndsctl $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/opennds/htdocs/images
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/usr/lib/opennds
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.html $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.css $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/status.html $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/opennds/htdocs/images/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/config/opennds $(1)/etc/config/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/init.d/opennds $(1)/etc/init.d/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/uci-defaults/40_opennds $(1)/etc/uci-defaults/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/usr/lib/opennds/restart.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/opennds/login.sh
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes-https.php $(1)/etc/opennds/
+endef
+
+define Package/opennds/postrm
+#!/bin/sh
+uci delete firewall.opennds
+uci commit firewall
+endef
+
+define Package/opennds/conffiles
+/etc/config/opennds
+endef
+
+$(eval $(call BuildPackage,opennds))


### PR DESCRIPTION
Maintainer: Rob White `<rob@blue-wave.net>`

Compiled and tested on snapshot SDK for mipsel_24kc, mips_24kc and arm_cortex-a7_neon-vfpv4

This is the first release from the OpenNDS project.

The decision has been made by the developers of the NoDogSplash project, to create a new project, beginning at v5.0.0

The two resulting projects are:

 * **OpenNDS**, the new project, optimised for development of custom captive portal solutions using the built in Forwarding authentication Services API and associated libraries.

 * **NoDogSplash**, the original project, optimised for hardware with very restricted resources (eg legacy 8/32 devices) and supporting only simple templated splash pages.

At v5.0.0 of both projects share a common code base.

However, the two packages will inevitably and rapidly diverge, as OpenNDS is actively developing, whereas NoDogSplash is feature complete for its optimised target use.

Signed-off-by: Rob White `<rob@blue-wave.net>`