### PR TITLE
[19.07] babeld: Update to version 1.9.2

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
-PKG_VERSION:=1.9.1
+PKG_VERSION:=1.9.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/
-PKG_HASH:=1e1b3c01dd929177bc8d027aff1494da75e1e567e1f60df3bb45a78d5f1ca0b4
+PKG_HASH:=154f00e0a8bf35d6ea9028886c3dc5c3c342dd1a367df55ef29a547b75867f07
 
 PKG_MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>, \
 	Baptiste Jonglez <openwrt-pkg@bitsofnetworks.org>


### PR DESCRIPTION
21 April 2020: babeld-1.9.2

  * Fixed two issues that could cause IPv4 routes to be represented
    incorrectly, with a range of confusing symptoms.  Thanks to
    Fabian Bläse.
  * Fixed incorrect parsing of TLVs with an unknown Address Encoding.
    Thanks to Théophile Bastian.
  * Fixed access to mis-aligned data structure.  Thanks to Antonin Décimo.

Signed-off-by: Fabian Bläse <fabian@blaese.de>