### PR TITLE
batman-adv 2020.1

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2020.0
+PKG_VERSION:=2020.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=1505bcb235289baaad25a5001a0189e4f16e5c4f023db62a8682c0eb91b162c0
+PKG_HASH:=e0721fb40b46c265433cbe6dfcba854e19dad1b69b62475dd01db7af503ea715
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2020.0
+PKG_VERSION:=2020.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=60efe9b148f66aa1b29110493244dc9f1f1d722e6d96969e4d4b2c0ab9278104
+PKG_HASH:=a3e21cbac5f7103925872d80d806d8677f034f8ae8bb6bf6296af81ab028c23b
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -73,13 +73,7 @@ NOSTDINC_FLAGS = \
 	-include $(PKG_BUILD_DIR)/compat-hacks.h \
 	-DBATADV_SOURCE_VERSION=\\\"$(PKG_VERSION)-openwrt-$(PKG_RELEASE)\\\"
 
-COMPAT_SOURCES = \
-	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
-	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
-	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
-
 define Build/Compile
-	+env "batman-adv-y=$(COMPAT_SOURCES)" \
 	$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
 		ARCH="$(LINUX_KARCH)" \
 		CROSS_COMPILE="$(TARGET_CROSS)" \

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2020.0
+PKG_VERSION:=2020.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=a12a32d1ec65b94b54ca86e6f31ac1b947bf04449aad0c96dfe936746bd0c585
+PKG_HASH:=23abf5576d4594c36a5b6a775f8d2bbd0025f004a8980f68358484f4a0730fbb
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>


### PR DESCRIPTION
@simonwunderlich

----

batman-adv 2020.1
=================

* support latest kernels (3.16 - 5.7)
* coding style cleanups and refactoring
* bugs squashed:
  * fix reference leaks in throughput_override sysfs file
  * fix reference leak in B.A.T.M.A.N. V OGM error handling
  * fix network coding random weighting

batctl 2020.1
=============

* bugs squashed:
  * Fix error code on throughputmeter errors