### PR TITLE
nodogsplash2: update to 2.1.2

### DIFF
--- a/nodogsplash2/Makefile
+++ b/nodogsplash2/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nodogsplash2
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=2.1.1
+PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/nodogsplash/nodogsplash/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=nodogsplash-$(PKG_VERSION).tar.gz
-PKG_HASH:=86463a93259f34745a7427d643e0810e7776d37470b32f4f823a1e6019ba9246
+PKG_HASH:=dcf64758b039ba821a4c2ba03ef1fba484aa792a1696050e42088f6c0c7c0bd8
 PKG_BUILD_DIR:=$(BUILD_DIR)/nodogsplash-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Moritz Warning <moritzwarning@web.de>


### PR DESCRIPTION
Fixes a path traversal.