### PR TITLE
opennds: Release v5.0.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=5.0.0
+PKG_VERSION:=5.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=ee31605327b515ccecbacca8404c2ae67a47357ea0201536943031f99c96fdb6
+PKG_HASH:=4af1ffed2c39267f8516f14bdd93d618fee7741dabbda1293c6390b0e648bd1c
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
Maintainer: Rob White <rob@blue-wave.net>

Compiled and tested on snapshot SDK for mipsel_24kc, mips_24kc and arm_cortex-a7_neon-vfpv4

This release provides a fix for a Path Traversal Attack vulnerability present in libmicrohttpd's built in unescape functionality.

Signed-off-by: Rob White <rob@blue-wave.net>