### PR TITLE
batman-adv: use KERNEL_MAKE_FLAGS for kernel module compilation

### DIFF
--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2020.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
@@ -75,8 +75,7 @@ NOSTDINC_FLAGS = \
 
 define Build/Compile
 	$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
-		ARCH="$(LINUX_KARCH)" \
-		CROSS_COMPILE="$(TARGET_CROSS)" \
+		$(KERNEL_MAKE_FLAGS) \
 		M="$(PKG_BUILD_DIR)/net/batman-adv" \
 		$(PKG_EXTRA_KCONFIG) \
 		EXTRA_CFLAGS="$(PKG_EXTRA_CFLAGS)" \

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -69,6 +69,7 @@ NOSTDINC_FLAGS = \
 	-I$(STAGING_DIR)/usr/include/mac80211 \
 	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
 	-I$(PKG_BUILD_DIR)/include/ \
+	-include backport/autoconf.h \
 	-include backport/backport.h \
 	-include $(PKG_BUILD_DIR)/compat-hacks.h \
 	-DBATADV_SOURCE_VERSION=\\\"$(PKG_VERSION)-openwrt-$(PKG_RELEASE)\\\"


### PR DESCRIPTION
It is easier to use the global define than to manually keep track of the changes in the various kernel module makefiles in the main OpenWrt repository and feeds. One effect should be that the absolute build_dir information is no longer included in the batman-adv.ko

Also the mac80211's autoconf.h is included to avoid ABI incompatibilities between mac80211 and batman-adv.