### PR TITLE
olsrd: mark as broken

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -36,7 +36,7 @@ endef
 define Package/olsrd
   $(call Package/olsrd/template)
   MENU:=1
-  DEPENDS:=+libpthread
+  DEPENDS:=+libpthread @BROKEN
 endef
 
 define Package/olsrd/conffiles


### PR DESCRIPTION
In October 2018 upstream started looking for a new maintainer and was going into "freeze" mode. No maintainer was found by February 2020 and the code has gone into "hard freeze", which in fact changed it to completely unmaintained.
Since February 2020 there is also issue #547, which is also stalled.

For this reason we mark this package as broken, till a new maintainer is found or it gets dropped completely.