### PR TITLE
opennds: Release v5.1.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=5.0.1
+PKG_VERSION:=5.1.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=4af1ffed2c39267f8516f14bdd93d618fee7741dabbda1293c6390b0e648bd1c
+PKG_HASH:=738c52d3d889edd02cd5935f5fcbc78fed0bd2163449a1947d00e755b7ae5b08
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -29,7 +29,7 @@ define Package/opennds
 	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
 	TITLE:=Open public network gateway daemon
 	URL:=https://github.com/opennds/opennds
-	CONFLICTS:=nodogsplash2, nodogsplash
+	CONFLICTS:=nodogsplash nodogsplash2
 endef
 
 define Package/opennds/description
@@ -59,13 +59,19 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/init.d/opennds $(1)/etc/init.d/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/uci-defaults/40_opennds $(1)/etc/uci-defaults/
 	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/usr/lib/opennds/restart.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/demo-preauth.sh $(1)/usr/lib/opennds/login.sh
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_log.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_sitewide.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/userlist.dat $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/splash_sitewide.html $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/login.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/login-remote-image.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid.php $(1)/etc/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes-https.php $(1)/etc/opennds/
 endef
 


### PR DESCRIPTION
Maintainer: Rob White <rob@blue-wave.net>

Compiled and tested using snapshot SDK for mipsel_24kc, mips_24kc and arm_cortex-a7_neon-vfpv4

OpenNDS v5.1.0 release

This release adds major functionality and provides numerous fixes:
Data Rate and Data Volume Quotas are implemented.
BinAuth / fas_secure_enabled level 3 compatibility is implemented.
Page fault and crash when ndsctl auth is called and client not found has been fixed.

From the ChangeLog:

  * Add - Generic Linux - install opennds.service [bluewavenet]
  * Add - Documentation updates [bluewavenet]
  * Add - config file updates [bluewavenet]
  * Add - Install sitewide username/password splash support files [bluewavenet]
  * Add - quotas to binauth_sitewide [bluewavenet]
  * Add - Splash page updates [bluewavenet]
  * Add - Implement Rate Quotas [bluewavenet]
  * Fix - check if idle preauthenticated [bluewavenet]
  * Add - support for rate quotas [bluewavenet]
  * Fix - Correctly compare client counters and clean up debuglevel messages [bluewavenet]
  * Add - Implement upload/download quotas Update fas-aes-https to support quotas [bluewavenet]
  * Add - Rename demo-preauth scripts and install all scripts [bluewavenet]
  * Add - fas-aes-https layout update [bluewavenet]
  * Add - Set some defaults in fas-aes-https [bluewavenet]
  * Add - custom data string to ndsctl auth [bluewavenet]
  * Add - custom data string to fas-hid.php [bluewavenet]
  * Add - Send custom data field to BinAuth via auth_client method [bluewavenet]
  * Fix - missing token value in auth_client [bluewavenet]
  * Add - upload/download quota and rate configuration values [bluewavenet]
  * Add - Send client token to binauth [bluewavenet]
  * Add - Rename upload_limit and download_limit to upload_rate and download_rate [bluewavenet]
  * Fix - Pass correct session end time to binauth [bluewavenet]
  * Add - some debuglevel 3 messages [bluewavenet]
  * Add - description of the favicon and page footer images [bluewavenet]
  * Add - Authmon collect authentication parameters from fas-aes-https [bluewavenet]
  * Add - sessionlength to ndsctl auth [bluewavenet]
  * Fix - Page fault when ndsctl auth is called and client not found [bluewavenet]
  * Add - Enable BinAuth / fas_secure_enabled level 3 compatibility [bluewavenet]
  * Fix - Correctly set BinAuth session_end [bluewavenet]
  * Add - Updates to Templated Splash pages [bluewavenet]
  * Add - Community Testing files [bluewavenet]
  * Fix - BinAuth error passing client session times [bluewavenet]
  * Fix - PHP notice - undefined constant [bluewavenet]
  * Fix - OpenWrt CONFLICTS variable in Makefile [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>