### PR TITLE
batman-adv 2020.2

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2020.1
-PKG_RELEASE:=1
+PKG_VERSION:=2020.2
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=e0721fb40b46c265433cbe6dfcba854e19dad1b69b62475dd01db7af503ea715
+PKG_HASH:=1cca2f600f585455a598c92de6fa2b4307c6fe76dddd9d4d29c7648212db9f5e
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2020.1
+PKG_VERSION:=2020.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=a3e21cbac5f7103925872d80d806d8677f034f8ae8bb6bf6296af81ab028c23b
+PKG_HASH:=d29cdb53ee68abd5027eae07d9fd645b3f154e0d577efa2666c1334bb6d60efd
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2020.1
-PKG_RELEASE:=2
+PKG_VERSION:=2020.2
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=23abf5576d4594c36a5b6a775f8d2bbd0025f004a8980f68358484f4a0730fbb
+PKG_HASH:=a73f5ce72c6efa9dd7bd7cc8daa667d0982e12e40811c978bb652607bb5666a3
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>


### PR DESCRIPTION
@simonwunderlich

----

batman-adv 2020.2
=================

* support latest kernels (4.4 - 5.8)
* coding style cleanups and refactoring
* dropped support for kernels < 4.4
* re-enabled link speed detection for interfaces without auto negotiation

batctl 2020.2
=============

* coding style cleanups and refactoring
* drop support for automatic destruction of empty meshifs
* bugs squashed:
  * Fix parsing of radiotap headers on big endian systems

alfred 2020.2
=============

* Rephrase names of server roles