### PR TITLE
batctl: Enable build of mcast_flags subcommand

### DIFF
--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
 PKG_VERSION:=2020.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
@@ -154,7 +154,7 @@ config-tables := \
 	claimtable \
 	dat_cache \
 	gateways \
-	loglevel \
+	mcast_flags \
 	nc_nodes \
 	neighbors \
 	originators \


### PR DESCRIPTION
The mcast_flags subcommand allows to query the mcast_flags of the current device and of the seen originators. It should be enabled for the default and full variants. But the configuration string wasn't correctly included in the list when the variants were prepared and thus disabled in all variants.

Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
Fixes: 129986825219 ("batctl: Provide different variants")

----

@simonwunderlich 