### PR TITLE
opennds: Release v6.0.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=5.1.0
+PKG_VERSION:=6.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=738c52d3d889edd02cd5935f5fcbc78fed0bd2163449a1947d00e755b7ae5b08
+PKG_HASH:=fff18a2871039a58a12794ecc6dacf77257f4bcc7bfa994ba9de70e0b786f322
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>


### PR DESCRIPTION
  * This version - for Openwrt **after** 19.07 - for compatibility with new MHD API
  * Set - minimum version of MHD to 0.9.71 for new MHD API [bluewavenet]
  * Set - use_outdated_mhd to 0 (disabled) as default [bluewavenet]
  * Add - Multifield PreAuth login script with css update [bluewavenet]
  * Add - Documentation and config option descriptions for configuring Walled Garden IP Sets

Signed-off-by: Rob White <rob@blue-wave.net>