### PR TITLE
openwrt-19.07: opennds: Backport v5.2.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -1,0 +1,88 @@
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=opennds
+PKG_FIXUP:=autoreconf
+PKG_VERSION:=5.2.0
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
+PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
+PKG_HASH:=8b8d8ab0b3d13f9b7c5fddb9423161e9e89c7051503ab219805209296eb00074
+PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
+
+PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
+PKG_BUILD_PARALLEL:=1
+PKG_LICENSE:=GPL-2.0+
+
+include $(INCLUDE_DIR)/package.mk
+
+
+define Package/opennds
+	SUBMENU:=Captive Portals
+	SECTION:=net
+	CATEGORY:=Network
+	DEPENDS:=+libpthread +iptables-mod-ipopt +libmicrohttpd-no-ssl
+	TITLE:=Open public network gateway daemon
+	URL:=https://github.com/opennds/opennds
+	CONFLICTS:=nodogsplash nodogsplash2
+endef
+
+define Package/opennds/description
+	openNDS is a Captive Portal that offers a simple way to
+	provide restricted access to the Internet by showing a splash
+	page to the user before Internet access is granted.
+	It also incorporates an API that allows the creation of
+	sophisticated authentication applications.
+endef
+
+define Package/opennds/install
+
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/opennds $(1)/usr/bin/
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ndsctl $(1)/usr/bin/
+
+	$(INSTALL_DIR) $(1)/etc/opennds/htdocs/images
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/usr/lib/opennds
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.html $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.css $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/status.html $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/opennds/htdocs/images/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/config/opennds $(1)/etc/config/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/init.d/opennds $(1)/etc/init.d/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/uci-defaults/40_opennds $(1)/etc/uci-defaults/
+	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/usr/lib/opennds/restart.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_log.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_sitewide.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/userlist.dat $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/splash_sitewide.html $(1)/etc/opennds/htdocs/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/login.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/login-remote-image.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid.php $(1)/etc/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes-https.php $(1)/etc/opennds/
+endef
+
+define Package/opennds/postrm
+#!/bin/sh
+uci delete firewall.opennds
+uci commit firewall
+endef
+
+define Package/opennds/conffiles
+/etc/config/opennds
+endef
+
+$(eval $(call BuildPackage,opennds))


### PR DESCRIPTION
opennds: Backport v5.2.0

Designed to replace the old NoDogsplash v4.0.3 package.
NoDogSplash v4.0.3 still contains the FAS API but has numerous bugs,
some serious, but is no longer supported as the decision was made to
split into two projects - openNDS with FAS and NoDogSplash optimised for
devices with minimal resources.

This version of openNDS is functionally the same as v6.0.0, but supports
libmicrohttpd (MHD) versions up to 0.9.70 that use the old MHD API.

There are many additions and bugfixes over NoDogSplash v4.0.3.
eg 
Bugfix:
 * Page fault when ndsctl auth is called and client not found
 * Missing NULL parameter in MHD_OPTION_UNESCAPE_CALLBACK causing page fault

Functionality:
 * HTTPS remote FAS
 * Upload/Download Quotas

From the Changelog:
openNDS (5.2.0)
  * This version - for backport to Openwrt 19.07 - for compatibility with old MHD API
  * Fix - Failure of MHD with some operating systems eg Debian [bluewavenet]
  * Fix - potential buffer truncation in ndsctl
  * Set - use_outdated_mhd to 1 (enabled) as default [bluewavenet]
  * Set - maximum permissible version of MHD to 0.9.70 to ensure old MHD API is used [bluewavenet]

openNDS (5.1.0)
  * Add - Generic Linux - install opennds.service [bluewavenet]
  * Add - Documentation updates [bluewavenet]
  * Add - config file updates [bluewavenet]
  * Add - Install sitewide username/password splash support files [bluewavenet]
  * Add - quotas to binauth_sitewide [bluewavenet]
  * Add - Splash page updates [bluewavenet]
  * Add - Implement Rate Quotas [bluewavenet]
  * Fix - check if idle preauthenticated [bluewavenet]
  * Add - support for rate quotas [bluewavenet]
  * Fix - Correctly compare client counters and clean up debuglevel messages [bluewavenet]
  * Add - Implement upload/download quotas Update fas-aes-https to support quotas [bluewavenet]
  * Add - Rename demo-preauth scripts and install all scripts [bluewavenet]
  * Add - fas-aes-https layout update [bluewavenet]
  * Add - Set some defaults in fas-aes-https [bluewavenet]
  * Add - custom data string to ndsctl auth [bluewavenet]
  * Add - custom data string to fas-hid.php [bluewavenet]
  * Add - Send custom data field to BinAuth via auth_client method [bluewavenet]
  * Fix - missing token value in auth_client [bluewavenet]
  * Add - upload/download quota and rate configuration values [bluewavenet]
  * Add - Send client token to binauth [bluewavenet]
  * Add - Rename upload_limit and download_limit to upload_rate and download_rate [bluewavenet]
  * Fix - Pass correct session end time to binauth [bluewavenet]
  * Add - some debuglevel 3 messages [bluewavenet]
  * Add - description of the favicon and page footer images [bluewavenet]
  * Add - Authmon collect authentication parameters from fas-aes-https [bluewavenet]
  * Add - sessionlength to ndsctl auth [bluewavenet]
  * Fix - Page fault when ndsctl auth is called and client not found [bluewavenet]
  * Add - Enable BinAuth / fas_secure_enabled level 3 compatibility [bluewavenet]
  * Fix - Correctly set BinAuth session_end [bluewavenet]
  * Add - Updates to Templated Splash pages [bluewavenet]
  * Add - Community Testing files [bluewavenet]
  * Fix - BinAuth error passing client session times [bluewavenet]
  * Fix - PHP notice - undefined constant [bluewavenet]
  * Fix - OpenWrt CONFLICTS variable in Makefile [bluewavenet]

openNDS (5.0.1)
  * Fix - Path Traversal Attack vulnerability allowed by libmicrohttpd's built in unescape functionality [bluewavenet] [lynxis]

openNDS (5.0.0)
  * Import - from NoDogSplash 4.5.0 allowing development without compromising NoDogSplash optimisation for minimum resource utilisation [bluewavenet]
  * Rename - from NoDogSplash to openNDS [bluewavenet]
  * Create - openNDS avatar and splash image [bluewavenet]
  * Move - wait_for_interface to opennds C code ensuring consistent start at boot time for all hardware, OpenWrt and Debian [bluewavenet]
  * Add - Enable https protocol for remote FAS [bluewavenet]
  * Add - trusted devices list to ndsctl json output [bluewavenet]
  * Add - option unescape_callback_enabled [bluewavenet]
  * Add - get_client_token library utility [bluewavenet]
  * Add - utf-8 to PreAuth header [bluewavenet]
  * Add - PreAuth Support for hashed id (hid) if sent by NDS [bluewavenet]
  * Add - library script shebang warning for systems not running Busybox [bluewavenet]
  * Add - htmlentityencode function, encode gatewayname in templated splash page [bluewavenet]
  * Add - htmlentity encode gatewayname on login page (PreAuth) [bluewavenet]
  * Add - Simple customisation of log file location for PreAuth and BinAuth [bluewavenet]
  * Add - option use_outdated_mhd [bluewavenet]
  * Add - url-encode and htmlentity-encode gatewayname on startup [bluewavenet]
  * Add - Allow special characters in username (PreAuth) [bluewavenet]
  * Add - Documentation updates [bluewavenet]
  * Add - Various style and cosmetic updates  [bluewavenet]
  * Fix - Change library script shebang to bash in Debian [bluewavenet]
  * Fix - Remove unnecessary characters causing script execution failure in Debian [bluewavenet]
  * Fix - Add missing NULL parameter in MHD_OPTION_UNESCAPE_CALLBACK [skra72] [bluewavenet]
  * Fix - Script failures running on Openwrt 19.07.0 [bluewavenet]
  * Fix - Preauth, status=authenticated [bluewavenet]
  * Fix - Prevent ndsctl from running if called from a Binauth script. [bluewavenet]
  * Fix - Minor changes in Library scripts for better portability [bluewavenet]
  * Fix - Prevent php notices on pedantic php servers [bluewavenet]
  * Fix - broken remote image retrieval (PreAuth) [bluewavenet]
  * Fix - Allow use of "#" in gatewayname [bluewavenet]

Tested on mips_24kc, mipsel_24kc, arm_cortex-a7_neon-vfpv4 and x86_64 platforms.

Signed-off-by: Rob White <rob@blue-wave.net>