### PR TITLE
batman-adv: upgrade package to latest release 2020.3

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2020.2
-PKG_RELEASE:=2
+PKG_VERSION:=2020.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=1cca2f600f585455a598c92de6fa2b4307c6fe76dddd9d4d29c7648212db9f5e
+PKG_HASH:=821739e570fc3da9936e70075ec04a3caf3b847cc8702f13a0725e903e637b8d
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2020.2
-PKG_RELEASE:=2
+PKG_VERSION:=2020.3
+PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=d29cdb53ee68abd5027eae07d9fd645b3f154e0d577efa2666c1334bb6d60efd
+PKG_HASH:=3513f7eb3f61817b6894b90832aa5eba513293f487d174ebc98f1bafc9165c64
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
 PKG_VERSION:=2020.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
@@ -154,7 +154,7 @@ config-tables := \
 	claimtable \
 	dat_cache \
 	gateways \
-	loglevel \
+	mcast_flags \
 	nc_nodes \
 	neighbors \
 	originators \

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2020.2
+PKG_VERSION:=2020.3
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=a73f5ce72c6efa9dd7bd7cc8daa667d0982e12e40811c978bb652607bb5666a3
+PKG_HASH:=65516dca919ea5be58d141c78bd1f0a94a02a784c5c85fb4e8f27f4226803f73
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
+++ b/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
@@ -8,6 +8,7 @@
 
 proto_batadv_hardif_init_config() {
 	proto_config_add_int 'elp_interval'
+	proto_config_add_int 'hop_penalty'
 	proto_config_add_string "master"
 	proto_config_add_string 'throughput_override'
 }
@@ -17,10 +18,12 @@ proto_batadv_hardif_setup() {
 	local iface="$2"
 
 	local elp_interval
+	local hop_penalty
 	local master
 	local throughput_override
 
 	json_get_vars elp_interval
+	json_get_vars hop_penalty
 	json_get_vars master
 	json_get_vars throughput_override
 
@@ -29,6 +32,7 @@ proto_batadv_hardif_setup() {
 	batctl meshif "$master" interface -M add "$iface"
 
 	[ -n "$elp_interval" ] && batctl hardif "$iface" elp_interval "$elp_interval"
+	[ -n "$hop_penalty" ] && batctl hardif "$iface" hop_penalty "$hop_penalty"
 	[ -n "$throughput_override" ] && batctl hardif "$iface" throughput_override "$throughput_override"
 
 	proto_init_update "$iface" 1


### PR DESCRIPTION
@simonwunderlich

---

batman-adv
==========

* support latest kernels (4.4 - 5.9)
* coding style cleanups and refactoring
* introduce a configurable per interface hop penalty
* bugs squashed:
  * avoid uninitialized chaddr when handling DHCP
  * fix own OGMv2 check in aggregation receive handling
  * fix "NOHZ: local_softirq_pending 08" warnings caused by BLA

batctl
====

* add per interface hop penalty command

alfred
====

* synchronization of batman-adv netlink header
