### PR TITLE
olsrd: migrate to using bison 3.7.1

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=olsrd
 PKG_SOURCE_DATE:=2020-06-18
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/OLSR/olsrd.git

--- a/olsrd/patches/011-bison.patch
+++ b/olsrd/patches/011-bison.patch
@@ -1,0 +1,16 @@
+--- a/src/cfgparser/local.mk
++++ b/src/cfgparser/local.mk
+@@ -74,12 +74,8 @@ $(C)oparse.c: $(C)oparse.y $(C)olsrd_conf.h $(C)Makefile
+ ifeq ($(VERBOSE),0)
+ 	@echo "[BISON] $@"
+ endif
+-	$(MAKECMDPREFIX)$(BISON) -d -o "$@-tmp" "$<"
+-	$(MAKECMDPREFIX)sed	-e 's/register //' \
+-		-e '/^#line/s/$(call quote,$@-tmp)/$(call quote,$@)/' \
+-		< "$@-tmp" >"$@"
+-	$(MAKECMDPREFIX)mv "$(subst .c,.h,$@-tmp)" "$(subst .c,.h,$@)"
+-	$(MAKECMDPREFIX)$(RM) "$@-tmp" "$(subst .c,.h,$@-tmp)"
++	$(MAKECMDPREFIX)$(BISON) -d -o "$@" "$<"
++	$(MAKECMDPREFIX)sed -e 's/register //' "$@" > "$@.o" && mv "$@.o" "$@"
+ 
+ $(C)oparse.o: CFLAGS := $(filter-out -Wunreachable-code,$(CFLAGS))


### PR DESCRIPTION
With the upgrade to bison 3.7.1 (openwrt commit 1cf842d) building
olsrd was failing.  Now, instead of the contents of header files
being directly inserted into the generated source files, they are
instead included with a #include directive.

The local.mk has, until now, done some magic with *-tmp files,
which is not longer necessary and even causes builds to fail.

src/cfgparser/oparse.c:265:10: fatal error: oparse.h-tmp: No such file or directory
 #include "oparse.h-tmp"

Suggested-by: Jo-Philipp Wich <jo@mein.io>
Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>