### PR TITLE
olsrd: adapt gpsdclient.c to new gpsd lib

### DIFF
--- a/olsrd/patches/012-gpsd.patch
+++ b/olsrd/patches/012-gpsd.patch
@@ -1,0 +1,11 @@
+--- a/lib/pud/src/gpsdclient.c
++++ b/lib/pud/src/gpsdclient.c
+@@ -370,7 +370,7 @@ void nmeaInfoFromGpsd(struct gps_data_t
+           );
+ 
+   gpsdata->set &= ~STATUS_SET; /* always valid */
+-  if (gpsdata->status == STATUS_NO_FIX) {
++  if (gpsdata->fix.status == STATUS_NO_FIX) {
+     nmeaInfoClear(info);
+     nmeaTimeSet(&info->utc, &info->present, NULL);
+     return;


### PR DESCRIPTION
As mentioned in gpsd.h:
"Move gps_data_t->status to gps_fix_t.status for better fix merging"