### PR TITLE
quagga: fix dependency to libcares

### DIFF
--- a/quagga/Makefile
+++ b/quagga/Makefile
@@ -174,6 +174,7 @@ CONFIGURE_ARGS+= \
 	--disable-ospfclient \
 	--disable-capabilities \
 	--disable-doc \
+	--disable-nhrpd \
 	$(call autoconf_bool,CONFIG_PACKAGE_quagga-libzebra,zebra) \
 	$(call autoconf_bool,CONFIG_PACKAGE_quagga-libospf,ospfd) \
 	$(call autoconf_bool,CONFIG_PACKAGE_quagga-bgpd,bgpd) \


### PR DESCRIPTION
Commit 9a89e57d7614 ("quagga: update to 1.2.4") introduced a dependency
to libcares.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>