### PR TITLE
batman-adv: upgrade package to latest release 2020.4

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
-PKG_VERSION:=2020.3
+PKG_VERSION:=2020.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=821739e570fc3da9936e70075ec04a3caf3b847cc8702f13a0725e903e637b8d
+PKG_HASH:=a22db18ec3ef6f12192d04bc6ca028c84e4a5951acb910fc5e17beefa24dc6ab
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
 PKG_LICENSE:=GPL-2.0-only MIT

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
-PKG_VERSION:=2020.3
+PKG_VERSION:=2020.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=3513f7eb3f61817b6894b90832aa5eba513293f487d174ebc98f1bafc9165c64
+PKG_HASH:=fc346005b3c19306ccf259329294d1d145a1294e04e9dbde2fb6c37697bb3917
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
-PKG_VERSION:=2020.3
+PKG_VERSION:=2020.4
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
-PKG_HASH:=65516dca919ea5be58d141c78bd1f0a94a02a784c5c85fb4e8f27f4226803f73
+PKG_HASH:=cdec428a2397c343fe4c08b1608479177497da7f60ba3cb9d2f1db64eb07b9b3
 PKG_EXTMOD_SUBDIRS:=net/batman-adv
 
 PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>

--- a/batman-adv/patches/0001-Revert-batman-adv-genetlink-move-to-smaller-ops-wher.patch
+++ b/batman-adv/patches/0001-Revert-batman-adv-genetlink-move-to-smaller-ops-wher.patch
@@ -1,0 +1,132 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sat, 24 Oct 2020 22:51:23 +0200
+Subject: Revert "batman-adv: genetlink: move to smaller ops wherever possible"
+
+The netlink genl_ops interface was splitted into two parts for Linux 5.10.
+The batman-adv code changed to the new one because it doesn't use the more
+complex policy handling of genl_ops. But the backports-5.8-1 version in
+OpenWrt doesn't yet support the new genl_small_ops.
+
+This patch must be dropped directly when OpenWrt switches to backports-5.10
+or newer - otherwise it will not work as expected.
+
+This reverts commit 725b4ef5be840cfcd0ca33b9393c14dee40c10f7.
+
+diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
+index f16355febac42294491531a3f8049bc680560d0c..d1f80cd88503cdd11e9051f2e90ea533bee89a67 100644
+--- a/compat-include/net/genetlink.h
++++ b/compat-include/net/genetlink.h
+@@ -31,17 +31,15 @@ void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
+ #endif /* LINUX_VERSION_IS_LESS(4, 15, 0) */
+ 
+ 
+-#if LINUX_VERSION_IS_LESS(5, 10, 0)
+-
+ #if LINUX_VERSION_IS_LESS(5, 2, 0)
++
+ enum genl_validate_flags {
+ 	GENL_DONT_VALIDATE_STRICT		= BIT(0),
+ 	GENL_DONT_VALIDATE_DUMP			= BIT(1),
+ 	GENL_DONT_VALIDATE_DUMP_STRICT		= BIT(2),
+ };
+-#endif /* LINUX_VERSION_IS_LESS(5, 2, 0) */
+ 
+-struct batadv_genl_small_ops {
++struct batadv_genl_ops {
+ 	int		       (*doit)(struct sk_buff *skb,
+ 				       struct genl_info *info);
+ 	int		       (*dumpit)(struct sk_buff *skb,
+@@ -70,9 +68,9 @@ struct batadv_genl_family {
+ 			 struct genl_info *info);
+         void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+ 			  struct genl_info *info);
+-	const struct batadv_genl_small_ops *small_ops;
++	const struct batadv_genl_ops *ops;
+ 	const struct genl_multicast_group *mcgrps;
+-	unsigned int n_small_ops;
++	unsigned int n_ops;
+ 	unsigned int n_mcgrps;
+ 	struct module *module;
+ 
+@@ -96,32 +94,24 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+ 	family->family.pre_doit = family->pre_doit;
+ 	family->family.post_doit = family->post_doit;
+ 	family->family.mcgrps = family->mcgrps;
+-	family->family.n_ops = family->n_small_ops;
++	family->family.n_ops = family->n_ops;
+ 	family->family.n_mcgrps = family->n_mcgrps;
+ 	family->family.module = family->module;
+ 
+-	ops = kzalloc(sizeof(*ops) * family->n_small_ops, GFP_KERNEL);
++	ops = kzalloc(sizeof(*ops) * family->n_ops, GFP_KERNEL);
+ 	if (!ops)
+ 		return -ENOMEM;
+ 
+ 	for (i = 0; i < family->family.n_ops; i++) {
+-		ops[i].doit = family->small_ops[i].doit;
+-		ops[i].dumpit = family->small_ops[i].dumpit;
+-		ops[i].done = family->small_ops[i].done;
+-		ops[i].cmd = family->small_ops[i].cmd;
+-		ops[i].internal_flags = family->small_ops[i].internal_flags;
+-		ops[i].flags = family->small_ops[i].flags;
+-#if LINUX_VERSION_IS_GEQ(5, 2, 0)
+-		ops[i].validate = family->small_ops[i].validate;
+-#else
++		ops[i].doit = family->ops[i].doit;
++		ops[i].dumpit = family->ops[i].dumpit;
++		ops[i].done = family->ops[i].done;
++		ops[i].cmd = family->ops[i].cmd;
++		ops[i].internal_flags = family->ops[i].internal_flags;
++		ops[i].flags = family->ops[i].flags;
+ 		ops[i].policy = family->policy;
+-#endif
+ 	}
+ 
+-#if LINUX_VERSION_IS_GEQ(5, 2, 0)
+-	family->family.policy = family->policy;
+-#endif
+-
+ 	family->family.ops = ops;
+ 	family->copy_ops = ops;
+ 
+@@ -136,7 +126,7 @@ typedef struct genl_ops batadv_genl_ops_old;
+ #define batadv_post_doit(__x, __y, __z) \
+ 	batadv_post_doit(const batadv_genl_ops_old *ops, __y, __z)
+ 
+-#define genl_small_ops batadv_genl_small_ops
++#define genl_ops batadv_genl_ops
+ #define genl_family batadv_genl_family
+ 
+ #define genl_register_family(family) \
+@@ -160,6 +150,6 @@ batadv_genl_unregister_family(struct batadv_genl_family *family)
+ 	genlmsg_multicast_netns(&(_family)->family, _net, _skb, _portid, \
+ 				_group, _flags)
+ 
+-#endif /* LINUX_VERSION_IS_LESS(5, 10, 0) */
++#endif /* LINUX_VERSION_IS_LESS(5, 2, 0) */
+ 
+ #endif /* _NET_BATMAN_ADV_COMPAT_NET_GENETLINK_H_ */
+diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+index c7a55647b520e87d560bdcb29a644eef30f2855c..dc193618a761c0b451e860ca83921007d286e09b 100644
+--- a/net/batman-adv/netlink.c
++++ b/net/batman-adv/netlink.c
+@@ -1350,7 +1350,7 @@ static void batadv_post_doit(const struct genl_ops *ops, struct sk_buff *skb,
+ 	}
+ }
+ 
+-static const struct genl_small_ops batadv_netlink_ops[] = {
++static const struct genl_ops batadv_netlink_ops[] = {
+ 	{
+ 		.cmd = BATADV_CMD_GET_MESH,
+ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+@@ -1484,8 +1484,8 @@ struct genl_family batadv_netlink_family __ro_after_init = {
+ 	.pre_doit = batadv_pre_doit,
+ 	.post_doit = batadv_post_doit,
+ 	.module = THIS_MODULE,
+-	.small_ops = batadv_netlink_ops,
+-	.n_small_ops = ARRAY_SIZE(batadv_netlink_ops),
++	.ops = batadv_netlink_ops,
++	.n_ops = ARRAY_SIZE(batadv_netlink_ops),
+ 	.mcgrps = batadv_netlink_mcgrps,
+ 	.n_mcgrps = ARRAY_SIZE(batadv_netlink_mcgrps),
+ };

--- a/batman-adv/src/compat-hacks.h
+++ b/batman-adv/src/compat-hacks.h
@@ -105,6 +105,50 @@ static inline int batadv_access_ok(int type, const void __user *p,
 
 #endif /* < KERNEL_VERSION(5, 4, 0) */
 
+#if LINUX_VERSION_IS_LESS(5, 10, 0)
+
+#include <linux/if_bridge.h>
+
+struct batadv_br_ip {
+	union {
+		__be32  ip4;
+#if IS_ENABLED(CONFIG_IPV6)
+		struct in6_addr ip6;
+#endif
+	} dst;
+	__be16          proto;
+	__u16           vid;
+};
+
+struct batadv_br_ip_list {
+	struct list_head list;
+	struct batadv_br_ip addr;
+};
+
+#if 0
+/* "static" dropped to force compiler to evaluate it as part of multicast.c
+ * might need to be added again and then called in some kind of dummy
+ * compat.c in case this header is included in multiple files.
+ */
+inline void __batadv_br_ip_list_check(void)
+{
+	BUILD_BUG_ON(sizeof(struct batadv_br_ip_list) != sizeof(struct br_ip_list));
+	BUILD_BUG_ON(offsetof(struct batadv_br_ip_list, list) != offsetof(struct br_ip_list, list));
+	BUILD_BUG_ON(offsetof(struct batadv_br_ip_list, addr) != offsetof(struct br_ip_list, addr));
+
+	BUILD_BUG_ON(sizeof(struct batadv_br_ip) != sizeof(struct br_ip));
+	BUILD_BUG_ON(offsetof(struct batadv_br_ip, dst.ip4) != offsetof(struct br_ip, u.ip4));
+	BUILD_BUG_ON(offsetof(struct batadv_br_ip, dst.ip6) != offsetof(struct br_ip, u.ip6));
+	BUILD_BUG_ON(offsetof(struct batadv_br_ip, proto) != offsetof(struct br_ip, proto));
+	BUILD_BUG_ON(offsetof(struct batadv_br_ip, vid) != offsetof(struct br_ip, vid));
+}
+#endif
+
+#define br_ip batadv_br_ip
+#define br_ip_list batadv_br_ip_list
+
+#endif /* LINUX_VERSION_IS_LESS(5, 10, 0) */
+
 /* <DECLARE_EWMA> */
 
 #include <linux/version.h>


### PR DESCRIPTION
@simonwunderlich

---

batman-adv
==========

* support latest kernels (4.4 - 5.10)
* coding style cleanups and refactoring
* bugs squashed:
  * fix incorrect reroute handling of multicast packets
  * improve handling of multicast packets by bridge loop avoidance

batctl
====

* bugs squashed:
  * Fix endianness in ICMPv6 Echo Request/Reply parsing
