### PR TITLE
opennds: Release 7.0.1

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=6.0.0
+PKG_VERSION:=7.0.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=fff18a2871039a58a12794ecc6dacf77257f4bcc7bfa994ba9de70e0b786f322
+PKG_HASH:=0470d893563768ca0ae35608c3495299cb9982e960d96c69d9e8bb4101afca12
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -69,6 +69,7 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/ipsetconfig.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid.php $(1)/etc/opennds/


### PR DESCRIPTION
This version introduces major new enhancements and the disabling or removal of deprecated functionality.

  * Add - built in autonomous Walled Garden operation [bluewavenet]
  * Add - Support for Custom Parameters [bluewavenet]
  * Add - Quota and rate reporting to ndsctl json. Format output and fix json syntax errors [bluewavenet]
  * Add - global quotas to output of ndsctl status [bluewavenet]
  * Add - Report Rate Check Window in ndsctl status and show client quotas [bluewavenet]
  * Add - gatewaymac to the encrypted query string [bluewavenet]
  * Add - support for login mode in PreAuth  [bluewavenet]
  * Fix - get_iface_ip in case of interface is vif or multihomed [bluewavenet]
  * Fix - Add missing client identifier argument in ndsctl help text [bluewavenet]
  * Fix - fix missing delimiter in fas-hid [bluewavenet]
  * Fix - get_client_interface for case of iw utility not available [bluewavenet]
  * Fix - php notice for pedantic php servers in post-request [bluewavenet]
  * Remove - support for deprecated RedirectURL [bluewavenet]
  * Deprecate - ndsctl clients option [bluewavenet]
  * Deprecate - legacy splash.html and disable it [bluewavenet]

Tested on OpenWrt (mipsel_24kc), Raspios-buster-lite (armhf), OpenSuse-Leap (x86-64)

Signed-off-by: Rob White <rob@blue-wave.net>