### PR TITLE
opennds: Release 8.0.0

### DIFF
--- a/opennds/Makefile
+++ b/opennds/Makefile
@@ -7,12 +7,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=opennds
 PKG_FIXUP:=autoreconf
-PKG_VERSION:=7.0.1
+PKG_VERSION:=8.0.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=https://codeload.github.com/opennds/opennds/tar.gz/v$(PKG_VERSION)?
 PKG_SOURCE:=opennds-$(PKG_VERSION).tar.gz
-PKG_HASH:=0470d893563768ca0ae35608c3495299cb9982e960d96c69d9e8bb4101afca12
+PKG_HASH:=5cd7f2f415dde36ff26aba246851a4ff972599c56073a3e1737020ada366d987
 PKG_BUILD_DIR:=$(BUILD_DIR)/openNDS-$(PKG_VERSION)
 
 PKG_MAINTAINER:=Rob White <rob@blue-wave.net>
@@ -55,21 +55,18 @@ define Package/opennds/install
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.css $(1)/etc/opennds/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/status.html $(1)/etc/opennds/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/resources/splash.jpg $(1)/etc/opennds/htdocs/images/
-	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/config/opennds $(1)/etc/config/
-	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/init.d/opennds $(1)/etc/init.d/
-	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/etc/uci-defaults/40_opennds $(1)/etc/uci-defaults/
-	$(CP) $(PKG_BUILD_DIR)/openwrt/opennds/files/usr/lib/opennds/restart.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/linux_openwrt/opennds/files/etc/config/opennds $(1)/etc/config/
+	$(CP) $(PKG_BUILD_DIR)/linux_openwrt/opennds/files/etc/init.d/opennds $(1)/etc/init.d/
+	$(CP) $(PKG_BUILD_DIR)/linux_openwrt/opennds/files/etc/uci-defaults/40_opennds $(1)/etc/uci-defaults/
+	$(CP) $(PKG_BUILD_DIR)/linux_openwrt/opennds/files/usr/lib/opennds/restart.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_log.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/binauth_sitewide.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/userlist.dat $(1)/etc/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/binauth/splash_sitewide.html $(1)/etc/opennds/htdocs/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/login.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/PreAuth/login-remote-image.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_interface.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/get_client_token.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/client_params.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/unescape.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/authmon.sh $(1)/usr/lib/opennds/
-	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/ipsetconfig.sh $(1)/usr/lib/opennds/
+	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/dnsconfig.sh $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/libs/post-request.php $(1)/usr/lib/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-aes/fas-aes.php $(1)/etc/opennds/
 	$(CP) $(PKG_BUILD_DIR)/forward_authentication_service/fas-hid/fas-hid.php $(1)/etc/opennds/


### PR DESCRIPTION
This version introduces major new functionality and some major changes
  * Rationalisation of support for multiple Linux distributions [bluewavenet]
  * Refactor login.sh script introducing base64 encoding and hashed token (hid) support [bluewavenet]
  * Refactor fas-hid script introducing base64 encoding and simplifying customisation of the script [bluewavenet]
  * Refactor binauth_log.sh and log BinAuth custom data as url encoded [bluewavenet]
  * Refactor fas-aes, simplifying customisation of the script [bluewavenet]
  * Refactor fas-aes-https, simplifying customisation of the script [bluewavenet]
  * Change - Use hid instead of tok when fas_secure_enabled >= 1 [bluewavenet]
  * Add - base64 encoding to fas_secure_enabled level 1 [bluewavenet]
  * Add - gatewyname, clientif, session_start, session_end and last_active to ndsctl json [bluewavenet]
  * Add - support for RFC6585 Status Code 511 - Network Authentication Required [bluewavenet]
  * Add - Client Status Page UI with Logout [bluewavenet]
  * Add - GatewayFQDN option [bluewavenet]
  * Add - client interface to status page query string [bluewavenet]
  * Add - support using base 64 encoded custom string for BinAuth and replace tok with hid [bluewavenet]
  * Add - base 64 decode option to ndsctl [bluewavenet]
  * Add - b64 encoding of querystring for level 1 [bluewavenet]
  * Add - Improved performance/user-experience on congested/slow systems using php FAS scripts [bluewavenet]
  * Add - support for ndsctl auth by hid in client_list [bluewavenet]
  * Add - Ensure faskey is set to default value (always enabled) [bluewavenet]
  * Add - Display error page on login failure in login.sh [bluewavenet]
  * Add - splash.html, add deprecation notice [bluewavenet]
  * Add - authmon, improved lock checking and introduce smaller loopinterval [bluewavenet]
  * Add - client_params, wait for ndsctl if it is busy [bluewavenet]
  * Add - fas-aes-https, allow progressive output to improve user experience on slow links [bluewavenet]
  * Fix - Block access to /opennds_preauth/ if PreAuth not enabled [bluewavenet]
  * Fix - On startup, call iptables_fw_destroy before doing any other setup [bluewavenet]
  * Fix - missing final redirect to originurl in fas-hid [bluewavenet]
  * Fix - ensure gatewayname is always urlencoded [bluewavenet]
  * Fix - client session end not set by binauth [bluewavenet]
  * Fix - Session timeout, if client setting is 0, default to global value [bluewavenet]
  * Fix - missing trailing separator on query and fix some compiler errors [bluewavenet]
  * Fix - ensure authmon daemon is killed if left running from previous crash [bluewavenet]
  * Fix - add missing query separator for custom FAS parameters [bluewavenet]
  * Fix - ndsctl auth, do not set quotas if client is already authenticated [bluewavenet]
  * Fix - client_params, show "Unlimited" when "null" is received from ndsctl json [bluewavenet]
  * Update configuration files [bluewavenet]
  * update documentation [bluewavenet]

Signed-off-by: Rob White <rob@blue-wave.net>