### PR TITLE
alfred: add "network" to reload triggers

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
 PKG_VERSION:=2021.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/alfred/files/alfred.init
+++ b/alfred/files/alfred.init
@@ -132,7 +132,7 @@ start_service() {
 }
 
 service_triggers() {
-	procd_add_reload_trigger "alfred"
+	procd_add_reload_trigger "alfred" "network"
 }
 
 stop_service() {


### PR DESCRIPTION
alfred uses properties from network interfaces, like the MAC
address. Since these might be altered by /etc/config/network,
alfred should be restarted on change.

---

@simonwunderlich @ecsv 

I also think this should be backported, but I'm waiting for the feedback on this PR first.