### PR TITLE
babeld: fix compiler warnings

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -45,7 +45,7 @@ struct xroute_list_entry {
 // List of received routes (to be used with ubox's list helpers).
 struct route_list_entry {
   struct list_head list;
-  struct route_stream *route;
+  struct babel_route *route;
 };
 
 // List of neighbours (to be used with ubox's list helpers).
@@ -55,7 +55,7 @@ struct neighbour_list_entry {
 };
 
 // Sends a babel info message on ubus socket.
-static void babeld_ubus_babeld_info(struct ubus_context *ctx_local,
+static int babeld_ubus_babeld_info(struct ubus_context *ctx_local,
                                     struct ubus_object *obj,
                                     struct ubus_request_data *req,
                                     const char *method, struct blob_attr *msg) {
@@ -73,6 +73,8 @@ static void babeld_ubus_babeld_info(struct ubus_context *ctx_local,
   ret = ubus_send_reply(ctx_local, req, b.head);
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
+
+  return ret;
 }
 
 // Appends an exported route message entry to the buffer.
@@ -87,9 +89,8 @@ static void babeld_add_xroute_buf(struct xroute *xroute, struct blob_buf *b) {
   blobmsg_close_table(b, prefix);
 }
 
-// Sends an exported routes message on ubus socket, splitting apart IPv4 and
-// IPv6 routes.
-static void babeld_ubus_get_xroutes(struct ubus_context *ctx_local,
+// Sends an exported routes message on ubus socket, splitting apart IPv4 and IPv6 routes.
+static int babeld_ubus_get_xroutes(struct ubus_context *ctx_local,
                                     struct ubus_object *obj,
                                     struct ubus_request_data *req,
                                     const char *method, struct blob_attr *msg) {
@@ -141,6 +142,8 @@ static void babeld_ubus_get_xroutes(struct ubus_context *ctx_local,
   ret = ubus_send_reply(ctx_local, req, b.head);
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
+
+  return ret;
 }
 
 // Appends an route message entry to the buffer.
@@ -188,9 +191,8 @@ static void babeld_add_route_buf(struct babel_route *route,
   blobmsg_close_table(b, prefix);
 }
 
-// Sends received routes message on ubus socket, splitting apart IPv4 and IPv6
-// routes.
-static void babeld_ubus_get_routes(struct ubus_context *ctx_local,
+// Sends received routes message on ubus socket, splitting apart IPv4 and IPv6 routes.
+static int babeld_ubus_get_routes(struct ubus_context *ctx_local,
                                    struct ubus_object *obj,
                                    struct ubus_request_data *req,
                                    const char *method, struct blob_attr *msg) {
@@ -242,6 +244,8 @@ static void babeld_ubus_get_routes(struct ubus_context *ctx_local,
   ret = ubus_send_reply(ctx_local, req, b.head);
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
+
+  return ret;
 }
 
 // Appends an neighbour entry to the buffer.
@@ -255,15 +259,14 @@ static void babeld_add_neighbour_buf(struct neighbour *neigh,
   blobmsg_add_u32(b, "uhello-reach", neigh->uhello.reach);
   blobmsg_add_u32(b, "rxcost", neighbour_rxcost(neigh));
   blobmsg_add_u32(b, "txcost", neigh->txcost);
-  blobmsg_add_u32(b, "rtt", format_thousands(neigh->rtt));
+  blobmsg_add_string(b, "rtt", format_thousands(neigh->rtt));
   blobmsg_add_u32(b, "channel", neigh->ifp->channel);
   blobmsg_add_u8(b, "if_up", if_up(neigh->ifp));
   blobmsg_close_table(b, neighbour);
 }
 
-// Sends neighbours message on ubus socket, splitting apart IPv4 and IPv6
-// neighbours.
-static void babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
+// Sends neighbours message on ubus socket, splitting apart IPv4 and IPv6 neighbours.
+static int babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
                                        struct ubus_object *obj,
                                        struct ubus_request_data *req,
                                        const char *method,
@@ -310,6 +313,8 @@ static void babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
   ret = ubus_send_reply(ctx_local, req, b.head);
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
+
+  return ret;
 }
 
 // List of functions we expose via the ubus bus.

--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -56,9 +56,9 @@ struct neighbour_list_entry {
 
 // Sends a babel info message on ubus socket.
 static int babeld_ubus_babeld_info(struct ubus_context *ctx_local,
-                                    struct ubus_object *obj,
-                                    struct ubus_request_data *req,
-                                    const char *method, struct blob_attr *msg) {
+                                   struct ubus_object *obj,
+                                   struct ubus_request_data *req,
+                                   const char *method, struct blob_attr *msg) {
   struct blob_buf b = {0};
   void *prefix;
   char host[64];
@@ -89,11 +89,12 @@ static void babeld_add_xroute_buf(struct xroute *xroute, struct blob_buf *b) {
   blobmsg_close_table(b, prefix);
 }
 
-// Sends an exported routes message on ubus socket, splitting apart IPv4 and IPv6 routes.
+// Sends an exported routes message on ubus socket, splitting apart IPv4 and
+// IPv6 routes.
 static int babeld_ubus_get_xroutes(struct ubus_context *ctx_local,
-                                    struct ubus_object *obj,
-                                    struct ubus_request_data *req,
-                                    const char *method, struct blob_attr *msg) {
+                                   struct ubus_object *obj,
+                                   struct ubus_request_data *req,
+                                   const char *method, struct blob_attr *msg) {
   struct blob_buf b = {0};
   struct xroute_stream *xroutes;
   struct xroute_list_entry *cur, *tmp;
@@ -191,11 +192,12 @@ static void babeld_add_route_buf(struct babel_route *route,
   blobmsg_close_table(b, prefix);
 }
 
-// Sends received routes message on ubus socket, splitting apart IPv4 and IPv6 routes.
+// Sends received routes message on ubus socket, splitting apart IPv4 and IPv6
+// routes.
 static int babeld_ubus_get_routes(struct ubus_context *ctx_local,
-                                   struct ubus_object *obj,
-                                   struct ubus_request_data *req,
-                                   const char *method, struct blob_attr *msg) {
+                                  struct ubus_object *obj,
+                                  struct ubus_request_data *req,
+                                  const char *method, struct blob_attr *msg) {
   struct blob_buf b = {0};
   struct route_stream *routes;
   struct route_list_entry *cur, *tmp;
@@ -265,12 +267,13 @@ static void babeld_add_neighbour_buf(struct neighbour *neigh,
   blobmsg_close_table(b, neighbour);
 }
 
-// Sends neighbours message on ubus socket, splitting apart IPv4 and IPv6 neighbours.
+// Sends neighbours message on ubus socket, splitting apart IPv4 and IPv6
+// neighbours.
 static int babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
-                                       struct ubus_object *obj,
-                                       struct ubus_request_data *req,
-                                       const char *method,
-                                       struct blob_attr *msg) {
+                                      struct ubus_object *obj,
+                                      struct ubus_request_data *req,
+                                      const char *method,
+                                      struct blob_attr *msg) {
   struct blob_buf b = {0};
   struct neighbour *neigh;
   struct neighbour_list_entry *cur, *tmp;
@@ -384,7 +387,8 @@ void ubus_notify_route(struct babel_route *route, int kind) {
 
 void ubus_notify_xroute(struct xroute *xroute, int kind) {
   struct blob_buf b = {0};
-  char method[50]; // possible methods are xroute.change, xroute.add, xroute.flush
+  char method[50]; // possible methods are xroute.change, xroute.add,
+                   // xroute.flush
 
   if (!babeld_object.has_subscribers)
     return;


### PR DESCRIPTION
Fixes:
- "route_list_entry" points to "struct babel_route"
- "format_thousands" returns a string pointer
- "UBUS_METHOD_NOARG" wants a function returning an integer