### PR TITLE
babeld: adopt to upstream header-style

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=5
+PKG_RELEASE:=$(AUTORELEASE)
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <sys/select.h>
 
+#include <libubus.h>
 #include <libubox/blob.h>
 #include <libubox/blobmsg.h>
 #include <libubox/list.h>

--- a/babeld/src/ubus.h
+++ b/babeld/src/ubus.h
@@ -21,7 +21,12 @@
 
 */
 
-#include <libubus.h>
+#include <stdbool.h>
+
+struct fd_set;
+struct neighbour;
+struct babel_route;
+struct xroute;
 
 // Whether to enable ubus bindings (boolean option).
 extern int ubus_bindings;

--- a/babeld/src/ubus.h
+++ b/babeld/src/ubus.h
@@ -23,9 +23,9 @@
 
 #include <stdbool.h>
 
+struct babel_route;
 struct fd_set;
 struct neighbour;
-struct babel_route;
 struct xroute;
 
 // Whether to enable ubus bindings (boolean option).

--- a/babeld/src/ubus.h
+++ b/babeld/src/ubus.h
@@ -22,9 +22,9 @@
 */
 
 #include <stdbool.h>
+#include <sys/select.h>
 
 struct babel_route;
-struct fd_set;
 struct neighbour;
 struct xroute;
 


### PR DESCRIPTION
Instead of including the headerfiles that define the structs, we add
the struct definitions to our headerfile.

Fixes warning:

```
ubus.h:67:32: warning: 'struct xroute' declared inside parameter list will not be visible outside of this definition or declaration
 void ubus_notify_xroute(struct xroute *xroute, int kind);
                                ^~~~~~
```