### PR TITLE
babeld: enable ubus by default

### DIFF
--- a/babeld/Makefile
+++ b/babeld/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=babeld
 PKG_VERSION:=1.9.2
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://www.irif.fr/~jch/software/files/

--- a/babeld/files/babeld.config
+++ b/babeld/files/babeld.config
@@ -24,7 +24,7 @@ config general
 	## See comment at the top of this file for more details.
 	# option 'conf_file' '/etc/babeld.conf'
 	# option 'conf_dir' '/tmp/babel.d/'
-	# option 'ubus_bindings' 'false'
+	option 'ubus_bindings' 'true'
 
 config interface
 	## Remove this line to enable babeld on this interface


### PR DESCRIPTION
"luci-app-babeld" is currently rewritten in javascript. We use the ubus-api to query all the statistics. That is why we should enable ubus_bindings by default.

https://github.com/openwrt/luci/pull/4779