### PR TITLE
ndppd: remove uClibc++ support

### DIFF
--- a/ndppd/Makefile
+++ b/ndppd/Makefile
@@ -9,20 +9,19 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=ndppd
 PKG_VERSION:=0.2.5
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 # Latest release
 PKG_SOURCE_URL:=https://codeload.github.com/DanielAdolfsson/ndppd/tar.gz/$(PKG_VERSION)?
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_HASH:=ee934167f8357f0bd0015e201a77fbe4d028c59e89dc98113805c6855e1c3992
-PKG_LICENSE:=GPL-3.0+
+PKG_LICENSE:=GPL-3.0-or-later
 
 # Development snapshot
 #PKG_SOURCE_URL=git://github.com/Tuhox/ndppd.git
 #PKG_SOURCE_VERSION=master
 #PKG_SOURCE_SUBDIR=$(PKG_NAME)-$(PKG_VERSION)
 
-include $(INCLUDE_DIR)/uclibc++.mk
 include $(INCLUDE_DIR)/package.mk
 
 define Package/ndppd
@@ -31,7 +30,7 @@ define Package/ndppd
   TITLE:=NDP Proxy Daemon
   URL:=http://www.priv.nu/projects/ndppd/
   MAINTAINER:=Gabriel Kerneis <gabriel@kerneis.info>
-  DEPENDS:=@IPV6 $(CXX_DEPENDS)
+  DEPENDS:=@IPV6 +libstdcpp
 endef
 
 define Package/ndppd/description


### PR DESCRIPTION
uClibc++ has been removed treewide. This is the last package.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @kerneis @mwarning 