### PR TITLE
CI: fix building multi-arch-test-build

### DIFF
--- a/.github/workflows/multi-arch-test-build.yml
+++ b/.github/workflows/multi-arch-test-build.yml
@@ -69,7 +69,7 @@ jobs:
           for ROOT in $PKG_ROOTS; do
             for CHANGE in $CHANGES; do
               if [[ "$CHANGE" == "$ROOT"* ]]; then
-                PACKAGES+=$(echo "$ROOT" | sed -e 's@.*/\(.*\)/@\1 @')
+                PACKAGES+=$(echo "$ROOT" | sed -e 's@\(.*\)/@\1 @')
                 break
               fi
             done


### PR DESCRIPTION
The sed is adding the package name as "PKGNAME/" and does not remove the "/". That is why the buildchain currently fails.
