### PR TITLE
olsrd: only pud depends on libgps

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -36,7 +36,7 @@ endef
 define Package/olsrd
   $(call Package/olsrd/template)
   MENU:=1
-  DEPENDS:=+libpthread +libgps
+  DEPENDS:=+libpthread
 endef
 
 define Package/olsrd/conffiles
@@ -125,7 +125,7 @@ endef
 
 define Package/olsrd-mod-pud
   $(call Package/olsrd/template)
-  DEPENDS:=olsrd
+  DEPENDS:=olsrd +libgps
   TITLE:=Position Update Distribution plugin
 endef
 


### PR DESCRIPTION
As a workaround for the glibc-fix the dependency on libgps was moved to olsrd. However, only pud is using this library.