### PR TITLE
olsrd: use SPDX

### DIFF
--- a/olsrd/Makefile
+++ b/olsrd/Makefile
@@ -1,8 +1,6 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 # Copyright (C) 2009-2016 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
 #
 
 include $(TOPDIR)/rules.mk


### PR DESCRIPTION
Use SPDX license headers to be machine readable.
