### PR TITLE
olsrd: change START from 65 to 80 in init scripts

### DIFF
--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -3,7 +3,7 @@
 
 . $IPKG_INSTROOT/lib/functions/olsrd.sh
 
-START=65
+START=80
 USE_PROCD=1
 BIN=/usr/sbin/olsrd
 OLSRD=olsrd

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -3,7 +3,7 @@
 
 . $IPKG_INSTROOT/lib/functions/olsrd.sh
 
-START=65
+START=80
 USE_PROCD=1
 BIN=/usr/sbin/olsrd
 OLSRD=olsrd6


### PR DESCRIPTION
On slower devices, the wireless network device might not
yet be set up completely when then olsrd(6) init script
runs.  This may cause the generated olsrd config file
to be missing the expected interface.  By putting olsrd(6) later
in the init sequence fixes this issue.

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>