### PR TITLE
olsrd: wait for wireless to initialize before starting

### DIFF
--- a/olsrd/files/olsrd4.init
+++ b/olsrd/files/olsrd4.init
@@ -15,10 +15,24 @@ wait_for_network()
 	ubus -t 15 wait_for network.interface.$1 2>/dev/null
 }
 
+wait_for_wireless()
+{
+	local count=0
+	ubus -t 15 wait_for network.wireless 2>/dev/null
+	while [ $count -lt 30 ]; do
+		if  [ "$(ubus call network.wireless status | jsonfilter -e '@[*]["pending"]' | grep true | wc -l)" == "0" ]; then
+			break
+		fi
+		count=$((count+1))
+		sleep 1
+	done
+}
+
 boot()
 {
 	config_load network
 	config_foreach wait_for_network interface
+	wait_for_wireless
 	rc_procd start_service
 }
 

--- a/olsrd/files/olsrd6.init
+++ b/olsrd/files/olsrd6.init
@@ -15,10 +15,24 @@ wait_for_network()
 	ubus -t 15 wait_for network.interface.$1 2>/dev/null
 }
 
+wait_for_wireless()
+{
+	local count=0
+	ubus -t 15 wait_for network.wireless 2>/dev/null
+	while [ $count -lt 30 ]; do
+		if  [ "$(ubus call network.wireless status | jsonfilter -e '@[*]["pending"]' | grep true | wc -l)" == "0" ]; then
+			break
+		fi
+		count=$((count+1))
+		sleep 1
+	done
+}
+
 boot()
 {
 	config_load network
 	config_foreach wait_for_network interface
+	wait_for_wireless
 	rc_procd start_service
 }
 


### PR DESCRIPTION
Wait for wireless to initialize (pending="false") to ensure
that any olsrd(6) configured interfaces and their associated
devices are up.  This provides the init script the ability
to properly add all interface sections to the generated
config file /tmp/etc/olsrd(6).conf

Signed-off-by: Perry Melange <isprotejesvalkata@gmail.com>