### PR TITLE
[21.02] babeld: free blob-buffers that are on stack

### DIFF
--- a/babeld/src/ubus.c
+++ b/babeld/src/ubus.c
@@ -74,6 +74,8 @@ static int babeld_ubus_babeld_info(struct ubus_context *ctx_local,
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
 
+  blob_buf_free(&b);
+
   return ret;
 }
 
@@ -143,6 +145,8 @@ static int babeld_ubus_get_xroutes(struct ubus_context *ctx_local,
   ret = ubus_send_reply(ctx_local, req, b.head);
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
+
+  blob_buf_free(&b);
 
   return ret;
 }
@@ -247,6 +251,8 @@ static int babeld_ubus_get_routes(struct ubus_context *ctx_local,
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
 
+  blob_buf_free(&b);
+
   return ret;
 }
 
@@ -317,6 +323,8 @@ static int babeld_ubus_get_neighbours(struct ubus_context *ctx_local,
   if (ret)
     fprintf(stderr, "Failed to send reply: %s\n", ubus_strerror(ret));
 
+  blob_buf_free(&b);
+
   return ret;
 }
 
@@ -383,6 +391,7 @@ void ubus_notify_route(struct babel_route *route, int kind) {
   babeld_add_route_buf(route, &b);
   snprintf(method, sizeof(method), "route.%s", local_kind(kind));
   ubus_notify(shared_ctx, &babeld_object, method, b.head, -1);
+  blob_buf_free(&b);
 }
 
 void ubus_notify_xroute(struct xroute *xroute, int kind) {
@@ -403,6 +412,7 @@ void ubus_notify_xroute(struct xroute *xroute, int kind) {
   babeld_add_xroute_buf(xroute, &b);
   snprintf(method, sizeof(method), "xroute.%s", local_kind(kind));
   ubus_notify(shared_ctx, &babeld_object, method, b.head, -1);
+  blob_buf_free(&b);
 }
 
 void ubus_notify_neighbour(struct neighbour *neigh, int kind) {
@@ -422,6 +432,7 @@ void ubus_notify_neighbour(struct neighbour *neigh, int kind) {
   babeld_add_neighbour_buf(neigh, &b);
   snprintf(method, sizeof(method), "neigh.%s", local_kind(kind));
   ubus_notify(shared_ctx, &babeld_object, method, b.head, -1);
+  blob_buf_free(&b);
 }
 
 void babeld_ubus_receive(fd_set *readfds) {


### PR DESCRIPTION
As Felix mentioned:
If a buffer was already allocated, blob_buf_init reuses it. You can
keep reusing it as many times as you want. You only need to call
blob_buf_free if you explicitly want to free the buffer memory
(e.g. on exit, or if the blob_buf is on stack).

http://lists.openwrt.org/pipermail/openwrt-devel/2021-October/036722.html

This PR frees the blob-buffers that are on the stack.

Signed-off-by: Nick Hainke <vincent@systemli.org>
(cherry picked from commit 6d463ca97cf329fe5b7bb29ff5581076ff7245f9)

Maintainer: @kerneis, @zorun, me
Compile tested: tbd
Run tested: tbd
