### PR TITLE
cjdns: patch of gyp imports support python3.11

### DIFF
--- a/cjdns/patches/050-fix-collections-mutableset.patch
+++ b/cjdns/patches/050-fix-collections-mutableset.patch
@@ -1,0 +1,17 @@
+--- a/node_build/dependencies/libuv/build/gyp/pylib/gyp/common.py
++++ b/node_build/dependencies/libuv/build/gyp/pylib/gyp/common.py
+@@ -498,7 +498,13 @@ def uniquer(seq, idfun=None):
+ 
+ 
+ # Based on http://code.activestate.com/recipes/576694/.
+-class OrderedSet(collections.MutableSet):
++try:
++  # For Python 3.10+
++  from collections.abc import MutableSet
++except ImportError:
++  MutableSet = collections.MutableSet
++
++class OrderedSet(MutableSet):
+   def __init__(self, iterable=None):
+     self.end = end = []
+     end += [None, end, end]         # sentinel node for doubly linked list


### PR DESCRIPTION
This solution:

First attempts to import MutableSet from collections.abc (Python 3.10+ location) Falls back to using collections.MutableSet for older Python versions Changes the class inheritance to use the properly imported MutableSet rather than directly referencing collections.MutableSet This approach ensures compatibility across different Python versions while maintaining the intended functionality of the OrderedSet class in the gyp build system.

Maintainer: me / @\<github-user> (find it by checking history of the package Makefile)
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
