### PR TITLE
[24.10] batman-adv: Merge bugfixes from 2026.1

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
 PKG_VERSION:=2024.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/alfred/patches/0001-alfred-Fix-printing-of-timespec.patch
+++ b/alfred/patches/0001-alfred-Fix-printing-of-timespec.patch
@@ -1,0 +1,44 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 8 Mar 2026 16:07:25 +0100
+Subject: alfred: Fix printing of timespec
+
+musl on a 32 bit system still uses a 64-bit value (long long) for the
+storage of tv_sec and tv_nsec. But the printf was evaluating these
+arguments always only as long.
+
+During the print of the nsec value, range of 0-999_999_999 is only
+possible. 30 bit is therefore enough to store this range. For simplicity,
+just use an unsigned int.
+
+The second value on the other hand can get up to 64 bit on a 64-bit-unix
+timestamp system. Just use long long for it to be on the safe side.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/alfred.git/commit/?id=b35a33063bf1f82fb43a689439c3f0bce631d712
+
+--- a/main.c
++++ b/main.c
+@@ -285,7 +285,9 @@ static struct globals *alfred_init(int a
+ 			sync_period = strtod(optarg, NULL);
+ 			globals->sync_period.tv_sec = (int)sync_period;
+ 			globals->sync_period.tv_nsec = (double)(sync_period - (int)sync_period) * 1e9;
+-			printf(" ** Setting sync interval to: %.9f seconds (%ld.%09ld)\n", sync_period, globals->sync_period.tv_sec, globals->sync_period.tv_nsec);
++			printf(" ** Setting sync interval to: %.9f seconds (%lld.%09u)\n", sync_period,
++			       (long long)globals->sync_period.tv_sec,
++			       (unsigned int)globals->sync_period.tv_nsec);
+ 			break;
+ 		case '4':
+ 			globals->ipv4mode = true;
+--- a/server.c
++++ b/server.c
+@@ -404,8 +404,8 @@ static void sync_period_timer(struct glo
+ 
+ 	if (globals->opmode == OPMODE_PRIMARY) {
+ 		/* we are a primary */
+-		printf("[%ld.%09ld] announce primary ...\n",
+-		       now.tv_sec, now.tv_nsec);
++		printf("[%lld.%09u] announce primary ...\n",
++		       (long long)now.tv_sec, (unsigned int)now.tv_nsec);
+ 		announce_primary(globals);
+ 		sync_data(globals);
+ 	} else {

--- a/batctl/Makefile
+++ b/batctl/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batctl
 PKG_VERSION:=2024.3
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batctl/patches/0003-batctl-tcpdump-Fix-printing-of-usecs.patch
+++ b/batctl/patches/0003-batctl-tcpdump-Fix-printing-of-usecs.patch
@@ -1,0 +1,27 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sun, 8 Mar 2026 15:52:30 +0100
+Subject: batctl: tcpdump: Fix printing of usecs
+
+musl on a 32 bit system still uses a 64-bit value (long long) for the
+storage of microseconds. But the printf was evaluating this argument always
+only as long.
+
+During the print of this usec value, range of 0-999_999 is only possible.
+20 bit is therefore enough to store this range. For simplicity, just use an
+unsigned int.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batctl.git/commit/?id=cc35fafeb49c709632eaf3089bbc87350ad7eef5
+
+--- a/tcpdump.c
++++ b/tcpdump.c
+@@ -96,7 +96,8 @@ static int print_time(void)
+ 	tm = localtime(&tv.tv_sec);
+ 
+ 	if (tm)
+-		printf("%02d:%02d:%02d.%06ld ", tm->tm_hour, tm->tm_min, tm->tm_sec, tv.tv_usec);
++		printf("%02d:%02d:%02d.%06u ", tm->tm_hour, tm->tm_min, tm->tm_sec,
++		       (unsigned int)tv.tv_usec);
+ 	else
+ 		printf("00:00:00.000000 ");
+ 

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2024.3
-PKG_RELEASE:=9
+PKG_RELEASE:=10
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/Makefile
+++ b/batman-adv/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=batman-adv
 PKG_VERSION:=2024.3
-PKG_RELEASE:=8
+PKG_RELEASE:=9
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)

--- a/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
+++ b/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-. /lib/functions.sh
-. ../netifd-proto.sh
-init_proto "$@"
+[ -n "$INCLUDE_ONLY" ] || {
+	. /lib/functions.sh
+	. ../netifd-proto.sh
+	init_proto "$@"
+}
 
 proto_batadv_vlan_init_config() {
 	proto_config_add_boolean 'ap_isolation:bool'
@@ -17,7 +19,7 @@ proto_batadv_vlan_setup() {
 
 	json_get_vars ap_isolation
 
-	[ -n "$ap_isolation" ] && batctl vlan "$iface" ap_isolation "$ap_isolation"
+	batctl vlan "$iface" ap_isolation "${ap_isolation:-0}"
 	proto_init_update "$iface" 1
 	proto_send_update "$config"
 }

--- a/batman-adv/patches/0013-batman-adv-avoid-OGM-aggregation-when-skb-tailroom-i.patch
+++ b/batman-adv/patches/0013-batman-adv-avoid-OGM-aggregation-when-skb-tailroom-i.patch
@@ -1,0 +1,35 @@
+From: Yang Yang <n05ec@lzu.edu.cn>
+Date: Sat, 14 Mar 2026 07:11:27 +0000
+Subject: batman-adv: avoid OGM aggregation when skb tailroom is insufficient
+
+When OGM aggregation state is toggled at runtime, an existing forwarded
+packet may have been allocated with only packet_len bytes, while a later
+packet can still be selected for aggregation. Appending in this case can
+hit skb_put overflow conditions.
+
+Reject aggregation when the target skb tailroom cannot accommodate the new
+packet. The caller then falls back to creating a new forward packet
+instead of appending.
+
+Fixes: 9f0c9aeb4de6 ("batman-adv: fix crash when new OGM is generated")
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Signed-off-by: Yuan Tan <tanyuan98@outlook.com>
+Signed-off-by: Xin Liu <bird@lzu.edu.cn>
+Signed-off-by: Ao Zhou <n05ec@lzu.edu.cn>
+Signed-off-by: Yang Yang <n05ec@lzu.edu.cn>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/?id=e86d615a4364151e08e351ab2c4b1d1f77c00361
+
+--- a/net/batman-adv/bat_iv_ogm.c
++++ b/net/batman-adv/bat_iv_ogm.c
+@@ -464,6 +464,9 @@ batadv_iv_ogm_can_aggregate(const struct
+ 	    !time_after_eq(aggregation_end_time, forw_packet->send_time))
+ 		return false;
+ 
++	if (skb_tailroom(forw_packet->skb) < packet_len)
++		return false;
++
+ 	if (aggregated_bytes > BATADV_MAX_AGGREGATION_BYTES)
+ 		return false;
+ 

--- a/batman-adv/patches/0014-batman-adv-reject-oversized-global-TT-response-buffe.patch
+++ b/batman-adv/patches/0014-batman-adv-reject-oversized-global-TT-response-buffe.patch
@@ -1,0 +1,55 @@
+From: Ruide Cao <caoruide123@gmail.com>
+Date: Thu, 2 Apr 2026 23:12:31 +0800
+Subject: batman-adv: reject oversized global TT response buffers
+
+batadv_tt_prepare_tvlv_global_data() builds the allocation length for a
+global TT response in 16-bit temporaries. When a remote originator
+advertises a large enough global TT, the TT payload length plus the VLAN
+header offset can exceed 65535 and wrap before kmalloc().
+
+The full-table response path still uses the original TT payload length when
+it fills tt_change, so the wrapped allocation is too small and
+batadv_tt_prepare_tvlv_global_data() writes past the end of the heap object
+before the later packet-size check runs.
+
+Fix this by rejecting TT responses whose TVLV value length cannot fit in
+the 16-bit TVLV payload length field.
+
+Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Co-developed-by: Yuan Tan <yuantan098@gmail.com>
+Signed-off-by: Yuan Tan <yuantan098@gmail.com>
+Suggested-by: Xin Liu <bird@lzu.edu.cn>
+Tested-by: Ren Wei <enjou1224z@gmail.com>
+Signed-off-by: Ruide Cao <caoruide123@gmail.com>
+Signed-off-by: Ren Wei <n05ec@lzu.edu.cn>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Signed-off-by: Simon Wunderlich <sw@simonwunderlich.de>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/?id=6043a632dd0677b8720b3f416553b67eef40bca4
+
+--- a/net/batman-adv/translation-table.c
++++ b/net/batman-adv/translation-table.c
+@@ -844,8 +844,8 @@ batadv_tt_prepare_tvlv_global_data(struc
+ {
+ 	u16 num_vlan = 0;
+ 	u16 num_entries = 0;
+-	u16 change_offset;
+-	u16 tvlv_len;
++	u16 tvlv_len = 0;
++	unsigned int change_offset;
+ 	struct batadv_tvlv_tt_vlan_data *tt_vlan;
+ 	struct batadv_orig_node_vlan *vlan;
+ 	u8 *tt_change_ptr;
+@@ -863,6 +863,11 @@ batadv_tt_prepare_tvlv_global_data(struc
+ 	if (*tt_len < 0)
+ 		*tt_len = batadv_tt_len(num_entries);
+ 
++	if (change_offset > U16_MAX || *tt_len > U16_MAX - change_offset) {
++		*tt_len = 0;
++		goto out;
++	}
++
+ 	tvlv_len = *tt_len;
+ 	tvlv_len += change_offset;
+ 

--- a/batman-adv/patches/0015-batman-adv-hold-claim-backbone-gateways-by-reference.patch
+++ b/batman-adv/patches/0015-batman-adv-hold-claim-backbone-gateways-by-reference.patch
@@ -1,0 +1,106 @@
+From: Haoze Xie <royenheart@gmail.com>
+Date: Mon, 6 Apr 2026 21:17:28 +0800
+Subject: batman-adv: hold claim backbone gateways by reference
+
+batadv_bla_add_claim() can replace claim->backbone_gw and drop the old
+gateway's last reference while readers still follow the pointer.
+
+The netlink claim dump path dereferences claim->backbone_gw->orig and
+takes claim->backbone_gw->crc_lock without pinning the underlying
+backbone gateway. batadv_bla_check_claim() still has the same naked
+pointer access pattern.
+
+Reuse batadv_bla_claim_get_backbone_gw() in both readers so they operate
+on a stable gateway reference until the read-side work is complete.
+This keeps the dump and claim-check paths aligned with the lifetime
+rules introduced for the other BLA claim readers.
+
+Fixes: a9ce0dc43e2c ("batman-adv: add basic bridge loop avoidance code")
+Fixes: 3b7a63606020 ("batman-adv: add B.A.T.M.A.N. Dump BLA claims via netlink")
+Reported-by: Yifan Wu <yifanwucs@gmail.com>
+Reported-by: Juefei Pu <tomapufckgml@gmail.com>
+Co-developed-by: Yuan Tan <yuantan098@gmail.com>
+Signed-off-by: Yuan Tan <yuantan098@gmail.com>
+Suggested-by: Xin Liu <bird@lzu.edu.cn>
+Signed-off-by: Haoze Xie <royenheart@gmail.com>
+Signed-off-by: Ao Zhou <n05ec@lzu.edu.cn>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/?id=cca46b5556f2f69162e9721f1834f85c60ae83e8
+
+--- a/net/batman-adv/bridge_loop_avoidance.c
++++ b/net/batman-adv/bridge_loop_avoidance.c
+@@ -2132,6 +2132,7 @@ batadv_bla_claim_dump_entry(struct sk_bu
+ 			    struct batadv_bla_claim *claim)
+ {
+ 	const u8 *primary_addr = primary_if->net_dev->dev_addr;
++	struct batadv_bla_backbone_gw *backbone_gw;
+ 	u16 backbone_crc;
+ 	bool is_own;
+ 	void *hdr;
+@@ -2147,32 +2148,35 @@ batadv_bla_claim_dump_entry(struct sk_bu
+ 
+ 	genl_dump_check_consistent(cb, hdr);
+ 
+-	is_own = batadv_compare_eth(claim->backbone_gw->orig,
+-				    primary_addr);
++	backbone_gw = batadv_bla_claim_get_backbone_gw(claim);
++
++	is_own = batadv_compare_eth(backbone_gw->orig, primary_addr);
+ 
+-	spin_lock_bh(&claim->backbone_gw->crc_lock);
+-	backbone_crc = claim->backbone_gw->crc;
+-	spin_unlock_bh(&claim->backbone_gw->crc_lock);
++	spin_lock_bh(&backbone_gw->crc_lock);
++	backbone_crc = backbone_gw->crc;
++	spin_unlock_bh(&backbone_gw->crc_lock);
+ 
+ 	if (is_own)
+ 		if (nla_put_flag(msg, BATADV_ATTR_BLA_OWN)) {
+ 			genlmsg_cancel(msg, hdr);
+-			goto out;
++			goto put_backbone_gw;
+ 		}
+ 
+ 	if (nla_put(msg, BATADV_ATTR_BLA_ADDRESS, ETH_ALEN, claim->addr) ||
+ 	    nla_put_u16(msg, BATADV_ATTR_BLA_VID, claim->vid) ||
+ 	    nla_put(msg, BATADV_ATTR_BLA_BACKBONE, ETH_ALEN,
+-		    claim->backbone_gw->orig) ||
++		    backbone_gw->orig) ||
+ 	    nla_put_u16(msg, BATADV_ATTR_BLA_CRC,
+ 			backbone_crc)) {
+ 		genlmsg_cancel(msg, hdr);
+-		goto out;
++		goto put_backbone_gw;
+ 	}
+ 
+ 	genlmsg_end(msg, hdr);
+ 	ret = 0;
+ 
++put_backbone_gw:
++	batadv_backbone_gw_put(backbone_gw);
+ out:
+ 	return ret;
+ }
+@@ -2468,6 +2472,7 @@ out:
+ bool batadv_bla_check_claim(struct batadv_priv *bat_priv,
+ 			    u8 *addr, unsigned short vid)
+ {
++	struct batadv_bla_backbone_gw *backbone_gw;
+ 	struct batadv_bla_claim search_claim;
+ 	struct batadv_bla_claim *claim = NULL;
+ 	struct batadv_hard_iface *primary_if = NULL;
+@@ -2490,9 +2495,13 @@ bool batadv_bla_check_claim(struct batad
+ 	 * return false.
+ 	 */
+ 	if (claim) {
+-		if (!batadv_compare_eth(claim->backbone_gw->orig,
++		backbone_gw = batadv_bla_claim_get_backbone_gw(claim);
++
++		if (!batadv_compare_eth(backbone_gw->orig,
+ 					primary_if->net_dev->dev_addr))
+ 			ret = false;
++
++		batadv_backbone_gw_put(backbone_gw);
+ 		batadv_claim_put(claim);
+ 	}
+ 


### PR DESCRIPTION
Maintainer: @simonwunderlich 
Compile tested: x86-64
Run tested: x86-64

Description:


batman-adv
==========

* avoid OGM aggregation when skb tailroom is insufficient
* reject oversized global TT response buffers
* hold claim backbone gateways by reference
* improve batadv_vlan.sh for LuCI

batctl
======

* tcpdump: Fix printing of usecs

alfred
======

* Fix printing of timespec

