### PR TITLE
bird2: bump to v2.18.1

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.18
+PKG_VERSION:=2.18.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=80e40ab7e73df9d521d5348cbb57b1399501af53f4d108fd8c24f6b14e3384c3
+PKG_HASH:=cb13248d6fe9c5f2b06d9d9e16983b4a6640ad94544499fc303f69688e89c50d
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @tohojo
Compile tested: snapshot x86_64
Run tested: snapshot x86/64 in a VM

Description:
