### PR TITLE
bird3: update to 3.2.1

### DIFF
--- a/bird3/Makefile
+++ b/bird3/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird3
-PKG_VERSION:=3.2.0
+PKG_VERSION:=3.2.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=5e6ff6a22cf92ba73ebf2e4bbcd9360328b52c7497ef70e4cf11089fa5a216b2
+PKG_HASH:=fbdacb9150f33ffe465f220e9c54ecae582551bb63146fa7148d12335e1fbfad
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Maintainer: @tohojo 
Compile tested: x86_64 snapshot
Run tested: x86/64 snapshot VM

Description:

Version 3.2.1 (2026-04-01)
  o ASPA: Fix downstream validation
  o BMP: Fix route sending
  o BGP: Fix route refresh after restart
  o BGP: Fix dynamic peer connection
  o Filters: Fix string attributes
  o Filters: Fix ROA check autoreload reconfiguration
  o Logging: Fix error handling
  o Kernel: Fix graceful recovery
  o Pipe: Fix rare collision bug
  o Config: Allow keyword redefinition