### PR TITLE
bird2: bump to v2.19.0

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.18.1
+PKG_VERSION:=2.19.0
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=cb13248d6fe9c5f2b06d9d9e16983b4a6640ad94544499fc303f69688e89c50d
+PKG_HASH:=484ad3f935e29eb7d40bb56fbd26c9a717f105c8780768e01c1821f17901ac00
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
This release fix problems below:
o BGP/MPLS Ethernet VPNs using VXLAN tunnels
o BGP: PMSI tunnel attribute
o Linux Netlink implementation for bridge interfaces o BGP: Automatic peering based on discovered neighbors o RAdv: Router discovery based on incoming Router Advertisments o Nest: Add message when attempting to reload protocol that is not UP o BMP: Fix off-by-one buffer overflow
o OSPF: Fix infinite loop in OSPF Graceful Restart o ASPA: Fix downstream validation
o Filters: Fix string attributes
o Logging: Fix error handling
o Minor filter improvements
o Various documentation fixes

Maintainer: @tohojo 
Compile tested: x86_64 vm
Run tested: x86_64 vm

Description:
