### PR TITLE
bird3: bump to v3.3.1

### DIFF
--- a/bird3/Makefile
+++ b/bird3/Makefile
@@ -3,12 +3,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird3
-PKG_VERSION:=3.2.1
+PKG_VERSION:=3.3.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=fbdacb9150f33ffe465f220e9c54ecae582551bb63146fa7148d12335e1fbfad
+PKG_HASH:=d5a8d651d6184c18252954932bb249dfee1fd213b3665cdd86226ac45edc0190
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Version 3.3.1 (2026-06-09)
  o BGP: Fix crash when incoming connection for disabled protocol arrives
  o BGP: Fix parsing labelled NLRIs with no next hop
  o RCU: Catch leaks sooner

Version 3.3.0 (2026-05-25)
  o BGP: Export memory consumption optimization
  o BGP: Fix hostentry handling of MPLS and EVPN routes
  o BGP: Block connections on explicitly disabled instances
  o Proto/CLI: Lock show-commands
  o Proto: Loop persists through down state
  o Nest/CLI: Show only the longest prefix match in 'show route for'
  o Nest: Lockless attribute cache
  o Removed locking in random number generation
  o ASPA: Fix downstream validation
  o BMP: Fix route sending
  o BGP: Fix route refresh after restart
  o BGP: Fix dynamic peer connection
  o Filters: Fix string attributes
  o Filters: Fix ROA check autoreload reconfiguration
  o Logging: Fix error handling
  o Kernel: Fix graceful recovery
  o Pipe: Fix rare collision bug
  o Config: Allow keyword redefinition
  o Merged 2.19

Maintainer: @PolynomialDivision & @tohojo 
Compile tested: (put here arch, model, OpenWrt version)
Run tested: (put here arch, model, OpenWrt version, tests done)

Description:
