### PR TITLE
bird2: bump to v2.19.2 [25.12]

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,12 +7,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
-PKG_VERSION:=2.18.2
+PKG_VERSION:=2.19.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
-PKG_HASH:=1c57639bdab25b04e96fb771faf58641cbcf1e8a4d5342e4cbfb111ed0b71fe8
+PKG_HASH:=aff89abba3b92b7637bd57e0168b8d7ae887747f160ada4973378ad72f5f3660
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 PKG_LICENSE:=GPL-2.0-or-later


### PR DESCRIPTION
Update to latest upstream bugfix release.

Cherry picked from commit 7c86b2ed077dc5e3b797407d112fbd970e9a7d53.

Maintainer: me 