### PR TITLE
alfred: clean up Makefile

### DIFF
--- a/alfred/Makefile
+++ b/alfred/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=alfred
 PKG_VERSION:=2026.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
@@ -31,7 +31,7 @@ define Package/alfred
   CATEGORY:=Network
   TITLE:=A.L.F.R.E.D. - Almighty Lightweight Fact Remote Exchange Daemon
   URL:=https://www.open-mesh.org/
-  DEPENDS:= +libc @IPV6 +libnl-tiny +librt \
+  DEPENDS:=@IPV6 +libnl-tiny +librt \
             +ALFRED_NEEDS_lua:lua \
             +ALFRED_NEEDS_libgps:libgps
 endef
@@ -54,6 +54,7 @@ endef
 
 define Package/alfred/conffiles
 /etc/config/alfred
+/etc/alfred/bat-hosts.lua
 endef
 
 define Package/alfred/config
@@ -64,21 +65,24 @@ MAKE_FLAGS += \
 	CONFIG_ALFRED_VIS=$(if $(CONFIG_PACKAGE_ALFRED_VIS),y,n) \
 	CONFIG_ALFRED_GPSD=$(if $(CONFIG_PACKAGE_ALFRED_GPSD),y,n) \
 	CONFIG_ALFRED_CAPABILITIES=n \
-        LIBNL_NAME="libnl-tiny" \
-        LIBNL_GENL_NAME="libnl-tiny" \
-        REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
+	LIBNL_NAME="libnl-tiny" \
+	LIBNL_GENL_NAME="libnl-tiny" \
+	REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
 
 define Package/alfred/install
 	$(INSTALL_DIR) $(1)/usr/sbin
-	cp -fpR  $(PKG_BUILD_DIR)/alfred $(1)/usr/sbin/
-	[ "x$(CONFIG_PACKAGE_ALFRED_VIS)" == "xy" ] && cp -fpR  $(PKG_BUILD_DIR)/vis/batadv-vis $(1)/usr/sbin/ ; true
-	[ "x$(CONFIG_PACKAGE_ALFRED_GPSD)" == "xy" ] && cp -fpR  $(PKG_BUILD_DIR)/gpsd/alfred-gpsd $(1)/usr/sbin/ ; true
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/alfred $(1)/usr/sbin/
+	$(if $(CONFIG_PACKAGE_ALFRED_VIS), \
+		$(INSTALL_BIN) $(PKG_BUILD_DIR)/vis/batadv-vis $(1)/usr/sbin/)
+	$(if $(CONFIG_PACKAGE_ALFRED_GPSD), \
+		$(INSTALL_BIN) $(PKG_BUILD_DIR)/gpsd/alfred-gpsd $(1)/usr/sbin/)
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/alfred.init $(1)/etc/init.d/alfred
 	$(INSTALL_DIR) $(1)/etc/config
 	$(INSTALL_CONF) ./files/alfred.config $(1)/etc/config/alfred
 	$(INSTALL_DIR) $(1)/etc/alfred
-	[ "x$(CONFIG_PACKAGE_ALFRED_BATHOSTS)" == "xy" ] && $(INSTALL_BIN) ./files/bat-hosts.lua $(1)/etc/alfred/bat-hosts.lua ; true
+	$(if $(CONFIG_PACKAGE_ALFRED_BATHOSTS), \
+		$(INSTALL_BIN) ./files/bat-hosts.lua $(1)/etc/alfred/bat-hosts.lua)
 endef
 
 $(eval $(call BuildPackage,alfred))

--- a/alfred/files/bat-hosts.lua
+++ b/alfred/files/bat-hosts.lua
@@ -4,6 +4,7 @@ local type_id = 64 -- bat-hosts
 
 function get_hostname()
   local hostfile = io.open("/proc/sys/kernel/hostname", "r")
+  if not hostfile then return nil end
   local ret_string = hostfile:read()
   hostfile:close()
   return ret_string
@@ -20,7 +21,10 @@ function get_interfaces_names()
 end
 
 function get_interface_address(name)
+  -- /sys/class/net also contains plain files, e.g. bonding_masters
+  -- once the bonding module is loaded, which have no address below them
   local addressfile = io.open("/sys/class/net/"..name.."/address", "r")
+  if not addressfile then return nil end
   local ret_string = addressfile:read()
   addressfile:close()
   return ret_string
@@ -37,7 +41,7 @@ local function generate_bat_hosts()
 
   for n, i in ipairs(get_interfaces_names()) do
     local address = get_interface_address(i)
-    if not ifaces[address] then ifaces[address] = i end
+    if address and not ifaces[address] then ifaces[address] = i end
   end
 
   for mac, iname in pairs(ifaces) do


### PR DESCRIPTION
Cleanup towards moving the package to openwrt/packages (#184):

- Install binaries with INSTALL_BIN instead of `cp -fpR`.
- Replace `[ "x$(CONFIG_...)" == "xy" ] && ... ; true` shell constructs (the `==` operator is a bashism) with make-level `$(if ...)` conditionals.
- Drop the explicit dependency on libc, which every package depends on implicitly.
- Indent MAKE_FLAGS consistently with tabs.

No functional change in the resulting package.

Maintainer: @simonwunderlich

