### PR TITLE
bird2, bird3: license identifier, bird3cl title and CPE ID

### DIFF
--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird2
 PKG_VERSION:=2.19.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
@@ -100,8 +100,6 @@ CONFIGURE_ARGS += --disable-libssh
 
 define Package/bird2/conffiles
 /etc/bird.conf
-/etc/bird4.conf
-/etc/bird6.conf
 endef
 
 define Package/bird2/install

--- a/bird2/Makefile
+++ b/bird2/Makefile
@@ -1,8 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0-only
 #
 # Copyright (C) 2009-2017 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
 
 include $(TOPDIR)/rules.mk
 

--- a/bird2/patches/000-ospf-bus-error.patch
+++ b/bird2/patches/000-ospf-bus-error.patch
@@ -1,3 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Reeve <matt@mreeve.com>
+Date: Tue, 10 Aug 2021 12:41:04 +0100
+Subject: [PATCH] Fix bus error on OSPF on IPQ806X
+
+On a Netgear R7800, if ospf v2 or v3 is configured in bird.conf, it fails
+to start with this error:
+
+    kernel: Alignment trap: not handling instruction f44c0a1f at [<00035848>]
+    kernel: Unhandled fault: alignment exception (0x801) at 0x007e0624
+
+The problem is due to a struct not being properly aligned on the ARMv7
+architecture.
+
+This patch fixes the problem by adding the "PACKED" macro to the affected
+struct. Note that upstream may later fix this in another way, in which
+case this patch will not be required.
+
+Upstream-Status: not submitted. As of 2.19.2 the structure still carries
+no alignment attribute.
+
+Signed-off-by: Matt Reeve <matt@mreeve.com>
+---
 --- a/proto/ospf/topology.h
 +++ b/proto/ospf/topology.h
 @@ -41,7 +41,7 @@ struct top_hash_entry

--- a/bird2/test-version.sh
+++ b/bird2/test-version.sh
@@ -1,1 +1,16 @@
-bird --version 2>&1 | grep "$PKG_VERSION" 
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bird2|bird2c|bird2cl)
+	# birdc and birdcl do not report a version; check the daemon,
+	# which both clients depend on anyway
+	bird --version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/bird3/Makefile
+++ b/bird3/Makefile
@@ -97,8 +97,6 @@ TARGET_LDFLAGS += -latomic
 
 define Package/bird3/conffiles
 /etc/bird.conf
-/etc/bird4.conf
-/etc/bird6.conf
 endef
 
 define Package/bird3/install

--- a/bird3/Makefile
+++ b/bird3/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=bird3
 PKG_VERSION:=3.3.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE:=bird-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://bird.nic.cz/download/
@@ -12,6 +12,7 @@ PKG_HASH:=21297d7a02edd700ae82de5a630055a9cb88a99e2e7e45551bc7d6c1e5b4de2c
 
 PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>, Nick Hainke <vincent@systemli.org>
 PKG_LICENSE:=GPL-2.0-or-later
+PKG_CPE_ID:=cpe:/a:nic:bird
 
 PKG_BUILD_DEPENDS:=ncurses readline
 PKG_BUILD_DIR:=$(BUILD_DIR)/bird-$(PKG_VERSION)
@@ -39,7 +40,7 @@ define Package/bird3c
 endef
 
 define Package/bird3cl
-  TITLE:=The BIRD lightweight command-line client (v2)
+  TITLE:=The BIRD lightweight command-line client (v3)
   URL:=https://bird.nic.cz/
   SECTION:=net
   CATEGORY:=Network

--- a/bird3/test-version.sh
+++ b/bird3/test-version.sh
@@ -1,1 +1,16 @@
-bird --version 2>&1 | grep "$PKG_VERSION" 
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+bird3|bird3c|bird3cl)
+	# birdc and birdcl do not report a version; check the daemon,
+	# which both clients depend on anyway
+	bird --version 2>&1 | grep -F "$PKG_VERSION"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Small fixes towards moving the packages to openwrt/packages (#184):

- bird2: replace the free-form license boilerplate with an SPDX license identifier.
- bird3: fix the bird3cl title, which still said "(v2)" (copy-paste leftover from bird2), and add PKG_CPE_ID (same product identifier as bird2) so published CVEs can be matched against the package.

Maintainers: @tohojo, @PolynomialDivision
