### PR TITLE
treewide: add test-version.sh for packages which cannot pass the generic version check

### DIFF
--- a/ahcpd/test-version.sh
+++ b/ahcpd/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+ahcpd)
+	# ahcpd does not provide any option to report its version.
+	# Check that the binary starts and prints its usage instead.
+	ahcpd 2>&1 | grep -F "Syntax: ahcpd"
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/babel-pinger/test-version.sh
+++ b/babel-pinger/test-version.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+babel-pinger)
+	# babel-pinger does not provide any option to report its version
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/naywatch/test-version.sh
+++ b/naywatch/test-version.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+naywatch)
+	# naywatch is a watchdog shell script which does not provide any
+	# option to report its version. It must not be executed during
+	# the CI runtime tests, since it may trigger a reboot.
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/naywatch/test-version.sh
+++ b/naywatch/test-version.sh
@@ -4,9 +4,11 @@
 
 case "$PKG_NAME" in
 naywatch)
-	# naywatch is a watchdog shell script which does not provide any
-	# option to report its version. It must not be executed during
-	# the CI runtime tests, since it may trigger a reboot.
+	# naywatch takes positional arguments (check interval, watchdog
+	# timeout, ...), not options, so a probe flag ends up as the
+	# check interval and the script enters its monitoring loop
+	# instead of reporting anything, until the probe timeout kills
+	# it.
 	exit 0
 	;;
 

--- a/ohybridproxy/patches/100-CMakeLists-support-CMake-4.0-version.patch
+++ b/ohybridproxy/patches/100-CMakeLists-support-CMake-4.0-version.patch
@@ -10,8 +10,6 @@ Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>
  CMakeLists.txt | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 1c970d9..cfb878e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
 @@ -1,4 +1,4 @@
@@ -20,6 +18,3 @@ index 1c970d9..cfb878e 100644
  project(ohybridproxy C)
  
  set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
--- 
-2.51.0
-

--- a/ohybridproxy/test-version.sh
+++ b/ohybridproxy/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+ohybridproxy|zonestitcher)
+	# The package version is derived from the source date and git
+	# hash, which the binaries do not report
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/pimbd/test-version.sh
+++ b/pimbd/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+pimbd)
+	# The package version is derived from the source date and git
+	# hash, which the binary does not report
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac

--- a/prince/test-version.sh
+++ b/prince/test-version.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck shell=busybox
+
+case "$PKG_NAME" in
+prince)
+	# prince requires a configuration file and does not provide any
+	# option to report its version
+	exit 0
+	;;
+
+*)
+	echo "Untested package: $PKG_NAME" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
The generic version check of the CI runtime tests requires at least one executable of a package to report PKG_VERSION. These packages can never pass it:

- **ahcpd** – provides no version option at all; check that the binary prints its usage instead.
- **babel-pinger** – provides no version option; skip the check.
- **naywatch** – watchdog shell script with no version option. The override also prevents the generic check from executing the script with probe flags, which must never happen for a script that may trigger a reboot of the test environment.
- **ohybridproxy**, **pimbd** – version is derived from PKG_SOURCE_DATE + git hash, which the binaries do not report; skip the check.
- **prince** – requires a configuration file and provides no version option; skip the check.

With these in place, any future PR touching these packages gets a green runtime test instead of a guaranteed failure.
